### PR TITLE
Fix duplicate standings rows and hydration mismatch

### DIFF
--- a/components/StatsBlock.vue
+++ b/components/StatsBlock.vue
@@ -2,12 +2,11 @@
   <tr
     v-for="(s, position) in standings"
     :key="position"
-    class="odd:bg-zinc-700 odd:bg-zinc-600 text-center"
+    class="odd:bg-zinc-700 text-center"
   >
-    <td v-if="s.conference === 'EAST'" style="background: #b9112d; color: white; font-size: 1.8em">
+    <td :style="{ background: s.conference === 'EAST' ? '#b9112d' : '#003872', color: 'white', fontSize: '1.8em' }">
       {{ position + 1 }}
     </td>
-    <td v-else style="background: #003872; color: white; font-size: 1.8em">{{ position + 1 }}</td>
     <td width="100" align="center">
         <img
           :src="`/logos/SVG/${s.short_name}.svg`"

--- a/composables/useConvexQueriesSSR.ts
+++ b/composables/useConvexQueriesSSR.ts
@@ -4,8 +4,6 @@ export async function useConvexQueriesSSR<T extends Array<Parameters<typeof useC
   queries: T
 ): Promise<{ data: Array<Ref<FunctionReturnType<T[number]> | undefined>> }> {
   const results = queries.map(q => useConvexQuery(q, {}))
-  if (import.meta.server) {
-    await Promise.all(results.map(r => r.suspense()))
-  }
+  await Promise.all(results.map(r => r.suspense()))
   return { data: results.map(r => r.data) }
 }

--- a/pages/standings.vue
+++ b/pages/standings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="standings">
+  <div>
     <table
       id="tableOverall"
       class="w-4/5 m-auto text-white"


### PR DESCRIPTION
- composables/useConvexQueriesSSR.ts: Always await suspense() on both server and client to ensure consistent data during hydration
- components/StatsBlock.vue: Replace v-if/v-else with dynamic :style binding
- pages/standings.vue: Use v-if=standingsData for consistent rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Standings table now renders consistently regardless of data presence.
  - Data loading is more consistent: all query results are awaited before display.

* **Refactor**
  - Simplified header presentation with a single dynamic style for consistent coloring and sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->