### PR TITLE
Add player page with a table of the top players by points

### DIFF
--- a/convex/playerStats.ts
+++ b/convex/playerStats.ts
@@ -69,11 +69,13 @@ export const getPlayerStatsByPlayerId = query({
   },
 });
 
-async function fetchPlayerStatsWithTeams(ctx: QueryCtx, year: number) {
-  const playerStats = await ctx.db
+async function fetchPlayerStatsWithTeams(ctx: QueryCtx, year: number, limit?: number) {
+  const query = ctx.db
     .query("playerStats")
-    .withIndex("year", (q) => q.eq("year", year))
-    .collect();
+    .withIndex("year_points", (q) => q.eq("year", year))
+    .order("desc");
+
+  const playerStats = limit ? await query.take(limit) : await query.collect();
 
   const teams = await ctx.db.query("teams").collect();
   const teamMap = new Map(teams.map((t) => [t._id.toString(), t]));
@@ -91,6 +93,13 @@ export const getPlayerStatsWithTeams = query({
   args: { year: v.number() },
   handler: async (ctx, args) => {
     return fetchPlayerStatsWithTeams(ctx, args.year);
+  },
+});
+
+export const getTopPlayerStatsWithTeams = query({
+  args: { year: v.number(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    return fetchPlayerStatsWithTeams(ctx, args.year, args.limit ?? 100);
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -74,5 +74,6 @@ export default defineSchema({
     .index("playerId", ["playerId"])
     .index("year", ["year"])
     .index("year_playerId", ["year", "playerId"])
-    .index("year_team_id", ["year", "team_id"]),
+    .index("year_team_id", ["year", "team_id"])
+    .index("year_points", ["year", "points"]),
 });

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -44,6 +44,7 @@
 const menuElements = [
   { name: 'Teams', url: '/teams' },
   { name: 'Standings', url: '/standings' },
+  { name: 'Player Stats', url: '/player-stats' },
   { name: 'MCP/AI tool', url: '/mcp' }
 ]
 

--- a/pages/player-stats.vue
+++ b/pages/player-stats.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <table class="w-4/5 m-auto text-white">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Team</th>
+          <th>Player</th>
+          <th>Pos</th>
+          <th>GP</th>
+          <th>G</th>
+          <th>A</th>
+          <th>PTS</th>
+          <th>+/-</th>
+          <th>PIM</th>
+          <th>S</th>
+          <th>S%</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="(player, index) in sortedPlayers"
+          :key="player._id"
+          class="odd:bg-zinc-700 text-center"
+        >
+          <td class="py-2 text-lg font-bold">{{ index + 1 }}</td>
+          <td class="py-2">
+            <img
+              :src="`/logos/SVG/${player.team?.short_name}.svg`"
+              class="h-8 mx-auto"
+              :alt="`${player.team?.city} ${player.team?.name}`"
+              :title="`${player.team?.city} ${player.team?.name}`"
+            >
+          </td>
+          <td class="py-2">{{ player.firstName }} {{ player.lastName }}</td>
+          <td class="py-2">{{ player.positionCode }}</td>
+          <td class="py-2">{{ player.gamesPlayed }}</td>
+          <td class="py-2">{{ player.goals }}</td>
+          <td class="py-2">{{ player.assists }}</td>
+          <td class="py-2 font-semibold">{{ player.points }}</td>
+          <td class="py-2">{{ player.plusMinus > 0 ? '+' : '' }}{{ player.plusMinus }}</td>
+          <td class="py-2">{{ player.penaltyMinutes }}</td>
+          <td class="py-2">{{ player.shots }}</td>
+          <td class="py-2">{{ (player.shootingPct * 100).toFixed(1) }}%</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { api } from "../convex/_generated/api"
+
+definePageMeta({
+  title: 'Player Stats'
+})
+
+const playerStatsQuery = useConvexQuery(api.playerStats.getTopPlayerStatsWithTeams, { year: 2026 })
+await playerStatsQuery.suspense()
+
+const sortedPlayers = computed(() => {
+  const data = playerStatsQuery.data.value
+  if (!data) return []
+  return data
+})
+</script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Player Stats" menu item and a new Player Stats page showing top players with detailed stats (rank, team logo, name, position, games, goals, assists, points, +/- , PIM, shots, shooting %).
  * New API endpoint to fetch top-N player stats (defaults to 100) with optional limit parameter.

* **Performance**
  * Added a year/points index to speed up top-player queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->