### PR TITLE
Add goalie statistics support (#41)

### DIFF
--- a/components/GoalieStatsTable.vue
+++ b/components/GoalieStatsTable.vue
@@ -88,14 +88,18 @@
         >
           <td class="py-2 text-lg font-bold">{{ index + 1 }}</td>
           <td class="py-2">
-            <NuxtLink :to="`/goalie-stats/${goalie.team?.short_name}`">
+            <NuxtLink
+              v-if="goalie.team"
+              :to="`/goalie-stats/${goalie.team.short_name}`"
+            >
               <img
-                :src="`/logos/SVG/${goalie.team?.short_name}.svg`"
+                :src="`/logos/SVG/${goalie.team.short_name}.svg`"
                 class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform"
-                :alt="`${goalie.team?.city} ${goalie.team?.name}`"
-                :title="`Click to filter by ${goalie.team?.city} ${goalie.team?.name}`"
+                :alt="`${goalie.team.city} ${goalie.team.name}`"
+                :title="`Click to filter by ${goalie.team.city} ${goalie.team.name}`"
               >
             </NuxtLink>
+            <span v-else class="text-zinc-400">-</span>
           </td>
           <td class="py-2">{{ goalie.firstName }} {{ goalie.lastName }}</td>
           <td class="py-2">{{ goalie.gamesPlayed }}</td>
@@ -142,10 +146,6 @@ const sortedTeams = computed(() => {
 
 function toggleSort(column: SortColumn) {
   let newDirection: SortDirection = 'desc'
-  // For GAA, lower is better, so default to asc
-  if (column === 'goalsAgainstAverage') {
-    newDirection = 'asc'
-  }
   if (props.sortBy === column) {
     newDirection = props.sortOrder === 'asc' ? 'desc' : 'asc'
   }

--- a/components/GoalieStatsTable.vue
+++ b/components/GoalieStatsTable.vue
@@ -1,0 +1,161 @@
+<template>
+  <div>
+    <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
+      <div class="flex items-center gap-4">
+        <label for="team-filter" class="text-white font-semibold">Filter by Team:</label>
+        <select
+          id="team-filter"
+          :value="selectedTeamShortName"
+          class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500"
+          @change="onTeamChange(($event.target as HTMLSelectElement).value)"
+        >
+          <option value="">All Teams</option>
+          <option v-for="team in sortedTeams" :key="team._id" :value="team.short_name">
+            {{ team.city }} {{ team.name }}
+          </option>
+        </select>
+      </div>
+      <div class="flex items-center gap-4">
+        <label for="goalie-search" class="sr-only">Search goalies</label>
+        <input
+          id="goalie-search"
+          v-model="searchQuery"
+          type="text"
+          placeholder="Search goalies..."
+          class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"
+        >
+      </div>
+    </div>
+    <table class="w-4/5 m-auto text-white">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Team</th>
+          <th>Goalie</th>
+          <th
+            class="cursor-pointer hover:text-blue-400 select-none"
+            @click="toggleSort('gamesPlayed')"
+          >
+            GP {{ sortIndicator('gamesPlayed') }}
+          </th>
+          <th>GS</th>
+          <th
+            class="cursor-pointer hover:text-blue-400 select-none"
+            @click="toggleSort('wins')"
+          >
+            W {{ sortIndicator('wins') }}
+          </th>
+          <th
+            class="cursor-pointer hover:text-blue-400 select-none"
+            @click="toggleSort('losses')"
+          >
+            L {{ sortIndicator('losses') }}
+          </th>
+          <th
+            class="cursor-pointer hover:text-blue-400 select-none"
+            @click="toggleSort('otLosses')"
+          >
+            OTL {{ sortIndicator('otLosses') }}
+          </th>
+          <th>SA</th>
+          <th>GA</th>
+          <th>SV</th>
+          <th
+            class="cursor-pointer hover:text-blue-400 select-none"
+            @click="toggleSort('savePct')"
+          >
+            SV% {{ sortIndicator('savePct') }}
+          </th>
+          <th
+            class="cursor-pointer hover:text-blue-400 select-none"
+            @click="toggleSort('goalsAgainstAverage')"
+          >
+            GAA {{ sortIndicator('goalsAgainstAverage') }}
+          </th>
+          <th
+            class="cursor-pointer hover:text-blue-400 select-none"
+            @click="toggleSort('shutouts')"
+          >
+            SO {{ sortIndicator('shutouts') }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="(goalie, index) in goalies"
+          :key="goalie._id"
+          class="even:bg-zinc-600 text-center"
+        >
+          <td class="py-2 text-lg font-bold">{{ index + 1 }}</td>
+          <td class="py-2">
+            <NuxtLink :to="`/goalie-stats/${goalie.team?.short_name}`">
+              <img
+                :src="`/logos/SVG/${goalie.team?.short_name}.svg`"
+                class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform"
+                :alt="`${goalie.team?.city} ${goalie.team?.name}`"
+                :title="`Click to filter by ${goalie.team?.city} ${goalie.team?.name}`"
+              >
+            </NuxtLink>
+          </td>
+          <td class="py-2">{{ goalie.firstName }} {{ goalie.lastName }}</td>
+          <td class="py-2">{{ goalie.gamesPlayed }}</td>
+          <td class="py-2">{{ goalie.gamesStarted }}</td>
+          <td class="py-2 font-semibold">{{ goalie.wins }}</td>
+          <td class="py-2">{{ goalie.losses }}</td>
+          <td class="py-2">{{ goalie.otLosses }}</td>
+          <td class="py-2">{{ goalie.shotsAgainst }}</td>
+          <td class="py-2">{{ goalie.goalsAgainst }}</td>
+          <td class="py-2">{{ goalie.saves }}</td>
+          <td class="py-2">{{ (goalie.savePct * 100).toFixed(1) }}%</td>
+          <td class="py-2">{{ goalie.goalsAgainstAverage.toFixed(2) }}</td>
+          <td class="py-2">{{ goalie.shutouts }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { api } from "../convex/_generated/api"
+import type { GoalieStatsWithTeam } from '~/types/goalies'
+
+type SortColumn = 'gamesPlayed' | 'wins' | 'losses' | 'otLosses' | 'savePct' | 'goalsAgainstAverage' | 'shutouts'
+type SortDirection = 'asc' | 'desc'
+
+const props = defineProps<{
+  goalies: GoalieStatsWithTeam[]
+  selectedTeamShortName: string
+  sortBy: SortColumn
+  sortOrder: SortDirection
+  onTeamChange: (value: string) => void
+  onSortChange: (column: SortColumn, direction: SortDirection) => void
+}>()
+
+const searchQuery = defineModel<string>('searchQuery', { default: '' })
+
+const { data: teams } = await useConvexQuery(api.teams.getTeams, {})
+
+const sortedTeams = computed(() => {
+  const teamsList = teams.value ?? []
+  return [...teamsList].sort((a, b) => a.city.localeCompare(b.city))
+})
+
+function toggleSort(column: SortColumn) {
+  let newDirection: SortDirection = 'desc'
+  // For GAA, lower is better, so default to asc
+  if (column === 'goalsAgainstAverage') {
+    newDirection = 'asc'
+  }
+  if (props.sortBy === column) {
+    newDirection = props.sortOrder === 'asc' ? 'desc' : 'asc'
+  }
+  props.onSortChange(column, newDirection)
+}
+
+function sortIndicator(column: SortColumn): string {
+  if (props.sortBy !== column) {
+    return ''
+  }
+  return props.sortOrder === 'asc' ? '↑' : '↓'
+}
+</script>

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as crons from "../crons.js";
+import type * as goalieStats from "../goalieStats.js";
 import type * as migrations from "../migrations.js";
 import type * as playerStats from "../playerStats.js";
 import type * as seed from "../seed.js";
@@ -23,6 +24,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   crons: typeof crons;
+  goalieStats: typeof goalieStats;
   migrations: typeof migrations;
   playerStats: typeof playerStats;
   seed: typeof seed;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -19,6 +19,13 @@ if (!isDev) {
     internal.playerStats.syncPlayerStatsAction,
     { year: 2026, limit: -1 }
   );
+
+  crons.cron(
+    "sync NHL goalie stats",
+    "22 11 * * *",
+    internal.goalieStats.syncGoalieStatsAction,
+    { year: 2026, limit: -1 }
+  );
 }
 
 export default crons;

--- a/convex/goalieStats.ts
+++ b/convex/goalieStats.ts
@@ -1,0 +1,304 @@
+import { query, internalAction, internalMutation } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+import { internal } from "./_generated/api";
+import { v } from "convex/values";
+
+interface NHLGoalieStats {
+  playerId: number;
+  goalieFullName: string;
+  lastName: string;
+  teamAbbrevs: string;
+  gamesPlayed: number;
+  gamesStarted: number;
+  wins: number;
+  losses: number;
+  otLosses: number;
+  shotsAgainst: number;
+  goalsAgainst: number;
+  saves: number;
+  savePct: number;
+  goalsAgainstAverage: number;
+  shutouts: number;
+  timeOnIce: number; // in minutes
+  goals: number | null;
+  assists: number | null;
+  penaltyMinutes: number | null;
+}
+
+export const getGoalieStatsWithTeamsByTeamSorted = query({
+  args: {
+    year: v.number(),
+    teamId: v.id("teams"),
+    sortBy: v.union(
+      v.literal("gamesPlayed"),
+      v.literal("wins"),
+      v.literal("losses"),
+      v.literal("otLosses"),
+      v.literal("savePct"),
+      v.literal("goalsAgainstAverage"),
+      v.literal("shutouts")
+    ),
+    sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
+  },
+  handler: async (ctx, args) => {
+    const goalieStats = await ctx.db
+      .query("goalieStats")
+      .withIndex("year_team_id", (q) =>
+        q.eq("year", args.year).eq("team_id", args.teamId)
+      )
+      .collect();
+
+    const order = args.sortOrder ?? "desc";
+    const sortKey = args.sortBy;
+
+    // For GAA, lower is better so default to asc
+    const isLowerBetter = sortKey === "goalsAgainstAverage";
+    const effectiveOrder = isLowerBetter ? (order === "asc" ? "desc" : "asc") : order;
+
+    const sortedStats = goalieStats.sort((a, b) => {
+      const aValue = a[sortKey];
+      const bValue = b[sortKey];
+      return effectiveOrder === "asc" ? aValue - bValue : bValue - aValue;
+    });
+
+    const team = await ctx.db.get(args.teamId);
+
+    return sortedStats.map((stat) => ({
+      ...stat,
+      team,
+    }));
+  },
+});
+
+export const searchGoalies = query({
+  args: {
+    query: v.string(),
+    teamId: v.optional(v.id("teams")),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const searchQuery = args.query.trim().toLowerCase();
+    if (!searchQuery) {
+      return [];
+    }
+
+    let goalieStats;
+    if (args.teamId) {
+      goalieStats = await ctx.db
+        .query("goalieStats")
+        .withSearchIndex("search_goalies", (q) =>
+          q.search("searchName", searchQuery).eq("team_id", args.teamId as Id<"teams">)
+        )
+        .take(args.limit ?? 20);
+    } else {
+      goalieStats = await ctx.db
+        .query("goalieStats")
+        .withSearchIndex("search_goalies", (q) =>
+          q.search("searchName", searchQuery)
+        )
+        .take(args.limit ?? 20);
+    }
+
+    const teams = await ctx.db.query("teams").collect();
+    const teamMap = new Map(teams.map((t) => [t._id.toString(), t]));
+
+    return goalieStats.map((stat) => {
+      const team = teamMap.get(stat.team_id.toString());
+      return {
+        ...stat,
+        team,
+      };
+    });
+  },
+});
+
+export const getGoalieStatsWithTeamsSorted = query({
+  args: {
+    year: v.number(),
+    sortBy: v.union(
+      v.literal("gamesPlayed"),
+      v.literal("wins"),
+      v.literal("losses"),
+      v.literal("otLosses"),
+      v.literal("savePct"),
+      v.literal("goalsAgainstAverage"),
+      v.literal("shutouts")
+    ),
+    sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const order = args.sortOrder ?? "desc";
+    const limit = args.limit ?? 100;
+
+    // For GAA, lower is better so default to asc
+    const isLowerBetter = args.sortBy === "goalsAgainstAverage";
+    const effectiveOrder = isLowerBetter ? (order === "asc" ? "desc" : "asc") : order;
+
+    const query = ctx.db
+      .query("goalieStats")
+      .withIndex(`year_${args.sortBy}`, (q) => q.eq("year", args.year))
+      .order(effectiveOrder);
+
+    const goalieStats = await query.take(limit);
+
+    const teams = await ctx.db.query("teams").collect();
+    const teamMap = new Map(teams.map((t) => [t._id.toString(), t]));
+
+    return goalieStats.map((stat) => {
+      const team = teamMap.get(stat.team_id.toString());
+      return {
+        ...stat,
+        team,
+      };
+    });
+  },
+});
+
+export const syncGoalieStatsAction = internalAction({
+  args: { year: v.number(), limit: v.number() },
+  handler: async (ctx, args) => {
+    const seasonId = "20252026";
+    const gameTypeId = 2;
+    const url = `https://api.nhle.com/stats/rest/en/goalie/summary?isAggregate=false&isGame=false&start=0&limit=${args.limit}&cayenneExp=gameTypeId=${gameTypeId}%20and%20seasonId=${seasonId}`;
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch goalie stats: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    const apiGoalieStats: NHLGoalieStats[] = data.data || [];
+
+    const goalieStats = apiGoalieStats.map((s) => {
+      const lastName = s.lastName;
+      const firstName = s.goalieFullName.replace(lastName, "").trim();
+
+      return {
+        playerId: s.playerId,
+        firstName,
+        lastName,
+        teamAbbrevs: s.teamAbbrevs,
+        gamesPlayed: s.gamesPlayed,
+        gamesStarted: s.gamesStarted,
+        wins: s.wins,
+        losses: s.losses,
+        otLosses: s.otLosses,
+        shotsAgainst: s.shotsAgainst,
+        goalsAgainst: s.goalsAgainst,
+        saves: s.saves,
+        savePct: s.savePct ?? 0,
+        goalsAgainstAverage: s.goalsAgainstAverage ?? 0,
+        shutouts: s.shutouts,
+        timeOnIce: s.timeOnIce ?? 0,
+        goals: s.goals ?? 0,
+        assists: s.assists ?? 0,
+        penaltyMinutes: s.penaltyMinutes ?? 0,
+      };
+    });
+
+    await ctx.runMutation(internal.goalieStats.syncGoalieStats, {
+      year: args.year,
+      goalieStats,
+    });
+
+    return { count: goalieStats.length };
+  },
+});
+
+export const syncGoalieStats = internalMutation({
+  args: {
+    year: v.number(),
+    goalieStats: v.array(
+      v.object({
+        playerId: v.number(),
+        firstName: v.string(),
+        lastName: v.string(),
+        teamAbbrevs: v.string(),
+        gamesPlayed: v.number(),
+        gamesStarted: v.number(),
+        wins: v.number(),
+        losses: v.number(),
+        otLosses: v.number(),
+        shotsAgainst: v.number(),
+        goalsAgainst: v.number(),
+        saves: v.number(),
+        savePct: v.number(),
+        goalsAgainstAverage: v.number(),
+        shutouts: v.number(),
+        timeOnIce: v.number(),
+        goals: v.optional(v.number()),
+        assists: v.optional(v.number()),
+        penaltyMinutes: v.optional(v.number()),
+      })
+    ),
+  },
+  handler: async (ctx, args) => {
+    const allTeams = await ctx.db.query("teams").collect();
+    const teamMap = new Map(allTeams.map((t) => [t.short_name, t._id]));
+
+    const existingGoalieStats = await ctx.db
+      .query("goalieStats")
+      .withIndex("year", (q) => q.eq("year", args.year))
+      .collect();
+    const existingMap = new Map(
+      existingGoalieStats.map((s) => [s.playerId, s._id])
+    );
+
+    let inserted = 0;
+    let updated = 0;
+
+    for (const goalieStat of args.goalieStats) {
+      // Handle goalies who played for multiple teams - take the last team
+      const teamAbbrevRaw = goalieStat.teamAbbrevs.includes(",")
+        ? goalieStat.teamAbbrevs.split(",").pop()
+        : goalieStat.teamAbbrevs;
+      const teamAbbrev = teamAbbrevRaw?.trim();
+      if (!teamAbbrev) {
+        console.log(`Team abbreviation not found for goalie: ${goalieStat.firstName} ${goalieStat.lastName}`);
+        continue;
+      }
+      const teamId = teamMap.get(teamAbbrev);
+
+      if (!teamId) {
+        console.log(`Team not found: ${goalieStat.teamAbbrevs}`);
+        continue;
+      }
+
+      const goalieStatsData = {
+        playerId: goalieStat.playerId,
+        firstName: goalieStat.firstName,
+        lastName: goalieStat.lastName,
+        searchName: `${goalieStat.firstName} ${goalieStat.lastName}`.toLowerCase(),
+        team_id: teamId,
+        year: args.year,
+        gamesPlayed: goalieStat.gamesPlayed,
+        gamesStarted: goalieStat.gamesStarted,
+        wins: goalieStat.wins,
+        losses: goalieStat.losses,
+        otLosses: goalieStat.otLosses,
+        shotsAgainst: goalieStat.shotsAgainst,
+        goalsAgainst: goalieStat.goalsAgainst,
+        saves: goalieStat.saves,
+        savePct: goalieStat.savePct,
+        goalsAgainstAverage: goalieStat.goalsAgainstAverage,
+        shutouts: goalieStat.shutouts,
+        timeOnIce: goalieStat.timeOnIce,
+        goals: goalieStat.goals,
+        assists: goalieStat.assists,
+        penaltyMinutes: goalieStat.penaltyMinutes,
+      };
+
+      const existingId = existingMap.get(goalieStat.playerId);
+      if (existingId) {
+        await ctx.db.patch(existingId, goalieStatsData);
+        updated++;
+      } else {
+        await ctx.db.insert("goalieStats", goalieStatsData);
+        inserted++;
+      }
+    }
+
+    return { inserted, updated };
+  },
+});

--- a/convex/goalieStats.ts
+++ b/convex/goalieStats.ts
@@ -1,5 +1,4 @@
 import { query, internalAction, internalMutation } from "./_generated/server";
-import type { Id } from "./_generated/dataModel";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
 
@@ -51,14 +50,10 @@ export const getGoalieStatsWithTeamsByTeamSorted = query({
     const order = args.sortOrder ?? "desc";
     const sortKey = args.sortBy;
 
-    // For GAA, lower is better so default to asc
-    const isLowerBetter = sortKey === "goalsAgainstAverage";
-    const effectiveOrder = isLowerBetter ? (order === "asc" ? "desc" : "asc") : order;
-
     const sortedStats = goalieStats.sort((a, b) => {
       const aValue = a[sortKey];
       const bValue = b[sortKey];
-      return effectiveOrder === "asc" ? aValue - bValue : bValue - aValue;
+      return order === "asc" ? aValue - bValue : bValue - aValue;
     });
 
     const team = await ctx.db.get(args.teamId);
@@ -83,11 +78,12 @@ export const searchGoalies = query({
     }
 
     let goalieStats;
-    if (args.teamId) {
+    const teamId = args.teamId;
+    if (teamId) {
       goalieStats = await ctx.db
         .query("goalieStats")
         .withSearchIndex("search_goalies", (q) =>
-          q.search("searchName", searchQuery).eq("team_id", args.teamId as Id<"teams">)
+          q.search("searchName", searchQuery).eq("team_id", teamId)
         )
         .take(args.limit ?? 20);
     } else {
@@ -131,14 +127,10 @@ export const getGoalieStatsWithTeamsSorted = query({
     const order = args.sortOrder ?? "desc";
     const limit = args.limit ?? 100;
 
-    // For GAA, lower is better so default to asc
-    const isLowerBetter = args.sortBy === "goalsAgainstAverage";
-    const effectiveOrder = isLowerBetter ? (order === "asc" ? "desc" : "asc") : order;
-
     const query = ctx.db
       .query("goalieStats")
       .withIndex(`year_${args.sortBy}`, (q) => q.eq("year", args.year))
-      .order(effectiveOrder);
+      .order(order);
 
     const goalieStats = await query.take(limit);
 

--- a/convex/playerStats.ts
+++ b/convex/playerStats.ts
@@ -1,5 +1,4 @@
 import { query, internalAction, internalMutation } from "./_generated/server";
-import type { QueryCtx } from "./_generated/server";
 import type { Id } from "./_generated/dataModel";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
@@ -32,51 +31,6 @@ interface NHLPlayerStats {
   shPoints: number;
   shootsCatches: string;
 }
-
-export const getPlayerStatsByYear = query({
-  args: { year: v.number() },
-  handler: async (ctx, args) => {
-    const playerStats = await ctx.db
-      .query("playerStats")
-      .withIndex("year", (q) => q.eq("year", args.year))
-      .collect();
-    return playerStats;
-  },
-});
-
-export const getPlayerStatsByTeam = query({
-  args: { year: v.number(), teamId: v.id("teams") },
-  handler: async (ctx, args) => {
-    const playerStats = await ctx.db
-      .query("playerStats")
-      .withIndex("year_team_id", (q) =>
-        q.eq("year", args.year).eq("team_id", args.teamId)
-      )
-      .collect();
-    return playerStats;
-  },
-});
-
-export const getPlayerStatsWithTeamsByTeam = query({
-  args: { year: v.number(), teamId: v.id("teams") },
-  handler: async (ctx, args) => {
-    const playerStats = await ctx.db
-      .query("playerStats")
-      .withIndex("year_team_id", (q) =>
-        q.eq("year", args.year).eq("team_id", args.teamId)
-      )
-      .collect();
-
-    const team = await ctx.db.get(args.teamId);
-
-    return playerStats
-      .sort((a, b) => b.points - a.points)
-      .map((stat) => ({
-        ...stat,
-        team,
-      }));
-  },
-});
 
 export const getPlayerStatsWithTeamsByTeamSorted = query({
   args: {
@@ -117,19 +71,6 @@ export const getPlayerStatsWithTeamsByTeamSorted = query({
       ...stat,
       team,
     }));
-  },
-});
-
-export const getPlayerStatsByPlayerId = query({
-  args: { year: v.number(), playerId: v.number() },
-  handler: async (ctx, args) => {
-    const playerStats = await ctx.db
-      .query("playerStats")
-      .withIndex("year_playerId", (q) =>
-        q.eq("year", args.year).eq("playerId", args.playerId)
-      )
-      .first();
-    return playerStats;
   },
 });
 
@@ -174,40 +115,6 @@ export const searchPlayers = query({
         team,
       };
     });
-  },
-});
-
-async function fetchPlayerStatsWithTeams(ctx: QueryCtx, year: number, limit?: number) {
-  const query = ctx.db
-    .query("playerStats")
-    .withIndex("year_points", (q) => q.eq("year", year))
-    .order("desc");
-
-  const playerStats = limit ? await query.take(limit) : await query.collect();
-
-  const teams = await ctx.db.query("teams").collect();
-  const teamMap = new Map(teams.map((t) => [t._id.toString(), t]));
-
-  return playerStats.map((stat) => {
-    const team = teamMap.get(stat.team_id.toString());
-    return {
-      ...stat,
-      team,
-    };
-  });
-}
-
-export const getPlayerStatsWithTeams = query({
-  args: { year: v.number() },
-  handler: async (ctx, args) => {
-    return fetchPlayerStatsWithTeams(ctx, args.year);
-  },
-});
-
-export const getTopPlayerStatsWithTeams = query({
-  args: { year: v.number(), limit: v.optional(v.number()) },
-  handler: async (ctx, args) => {
-    return fetchPlayerStatsWithTeams(ctx, args.year, args.limit ?? 100);
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -88,4 +88,48 @@ export default defineSchema({
       searchField: "searchName",
       filterFields: ["team_id"],
     }),
+
+  goalieStats: defineTable({
+    playerId: v.number(),
+    firstName: v.string(),
+    lastName: v.string(),
+    searchName: v.string(), // Combined first + last name for search
+    team_id: v.id("teams"),
+    year: v.number(),
+    // Games
+    gamesPlayed: v.number(),
+    gamesStarted: v.number(),
+    // Record
+    wins: v.number(),
+    losses: v.number(),
+    otLosses: v.number(),
+    // Stats
+    shotsAgainst: v.number(),
+    goalsAgainst: v.number(),
+    saves: v.number(),
+    savePct: v.number(),
+    goalsAgainstAverage: v.number(),
+    shutouts: v.number(),
+    // Time
+    timeOnIce: v.number(), // in minutes
+    // Additional
+    goals: v.optional(v.number()),
+    assists: v.optional(v.number()),
+    penaltyMinutes: v.optional(v.number()),
+  })
+    .index("playerId", ["playerId"])
+    .index("year", ["year"])
+    .index("year_playerId", ["year", "playerId"])
+    .index("year_team_id", ["year", "team_id"])
+    .index("year_gamesPlayed", ["year", "gamesPlayed"])
+    .index("year_wins", ["year", "wins"])
+    .index("year_losses", ["year", "losses"])
+    .index("year_otLosses", ["year", "otLosses"])
+    .index("year_savePct", ["year", "savePct"])
+    .index("year_goalsAgainstAverage", ["year", "goalsAgainstAverage"])
+    .index("year_shutouts", ["year", "shutouts"])
+    .searchIndex("search_goalies", {
+      searchField: "searchName",
+      filterFields: ["team_id"],
+    }),
 });

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -54,6 +54,7 @@ const menuElements = [
   { name: 'Teams', url: '/teams' },
   { name: 'Standings', url: '/standings' },
   { name: 'Player Stats', url: '/player-stats' },
+  { name: 'Goalie Stats', url: '/goalie-stats' },
   { name: 'MCP/AI tool', url: '/mcp' },
   { name: 'About', url: '/about' }
 ]

--- a/pages/goalie-stats/[team].vue
+++ b/pages/goalie-stats/[team].vue
@@ -1,0 +1,84 @@
+<template>
+  <GoalieStatsTable
+    v-model:search-query="searchQuery"
+    :goalies="goalies"
+    :selected-team-short-name="teamParam"
+    :sort-by="sortBy"
+    :sort-order="sortOrder"
+    :on-team-change="onTeamChange"
+    :on-sort-change="onSortChange"
+  />
+</template>
+
+<script setup lang="ts">
+import { api } from "../../convex/_generated/api"
+import type { Id } from "../../convex/_generated/dataModel"
+import type { FunctionReturnType } from "convex/server"
+
+type Teams = FunctionReturnType<typeof api.teams.getTeams>
+type SortColumn = 'gamesPlayed' | 'wins' | 'losses' | 'otLosses' | 'savePct' | 'goalsAgainstAverage' | 'shutouts'
+type SortDirection = 'asc' | 'desc'
+
+const route = useRoute()
+const router = useRouter()
+
+useHead({
+  title: 'Goalie Stats'
+})
+
+const teamParam = computed(() => route.params.team as string)
+const sortBy = ref<SortColumn>('wins')
+const sortOrder = ref<SortDirection>('desc')
+const searchQuery = ref('')
+const debouncedSearchQuery = refDebounced(searchQuery, 200)
+
+const { data: teams } = await useConvexQuery(api.teams.getTeams, {})
+
+const selectedTeamId = computed<Id<"teams"> | undefined>(() => {
+  const team = teams.value?.find((t: Teams[number]) => t.short_name === teamParam.value)
+  return team?._id
+})
+
+type GoalieStatsArgs = { year: number, teamId: Id<"teams">, sortBy: SortColumn, sortOrder: SortDirection }
+
+const queryArgs = computed<GoalieStatsArgs | null>(() => selectedTeamId.value ? {
+  year: 2026,
+  teamId: selectedTeamId.value,
+  sortBy: sortBy.value,
+  sortOrder: sortOrder.value,
+} : null)
+
+const { data: teamGoalies } = await useConvexQuery(
+  api.goalieStats.getGoalieStatsWithTeamsByTeamSorted,
+  queryArgs
+)
+
+const { data: searchResults } = await useConvexQuery(
+  api.goalieStats.searchGoalies,
+  computed(() => ({
+    query: debouncedSearchQuery.value,
+    teamId: selectedTeamId.value,
+    limit: 20,
+  }))
+)
+
+const goalies = computed(() => {
+  if (debouncedSearchQuery.value.trim()) {
+    return searchResults.value ?? []
+  }
+  return teamGoalies.value ?? []
+})
+
+function onTeamChange(value: string) {
+  if (value) {
+    router.push(`/goalie-stats/${value}`)
+  } else {
+    router.push('/goalie-stats')
+  }
+}
+
+function onSortChange(column: SortColumn, direction: SortDirection) {
+  sortBy.value = column
+  sortOrder.value = direction
+}
+</script>

--- a/pages/goalie-stats/index.vue
+++ b/pages/goalie-stats/index.vue
@@ -1,0 +1,65 @@
+<template>
+  <GoalieStatsTable
+    v-model:search-query="searchQuery"
+    :goalies="goalies"
+    :selected-team-short-name="''"
+    :sort-by="sortBy"
+    :sort-order="sortOrder"
+    :on-team-change="onTeamChange"
+    :on-sort-change="onSortChange"
+  />
+</template>
+
+<script setup lang="ts">
+import { api } from "../../convex/_generated/api"
+
+type SortColumn = 'gamesPlayed' | 'wins' | 'losses' | 'otLosses' | 'savePct' | 'goalsAgainstAverage' | 'shutouts'
+type SortDirection = 'asc' | 'desc'
+
+const router = useRouter()
+
+const sortBy = ref<SortColumn>('wins')
+const sortOrder = ref<SortDirection>('desc')
+const searchQuery = ref('')
+const debouncedSearchQuery = refDebounced(searchQuery, 200)
+
+const { data: goaliesData } = await useConvexQuery(
+  api.goalieStats.getGoalieStatsWithTeamsSorted,
+  computed(() => ({
+    year: 2026,
+    sortBy: sortBy.value,
+    sortOrder: sortOrder.value,
+    limit: 100,
+  }))
+)
+
+const { data: searchResults } = await useConvexQuery(
+  api.goalieStats.searchGoalies,
+  computed(() => ({
+    query: debouncedSearchQuery.value,
+    limit: 20,
+  }))
+)
+
+const goalies = computed(() => {
+  if (debouncedSearchQuery.value.trim()) {
+    return searchResults.value ?? []
+  }
+  return goaliesData.value ?? []
+})
+
+function onTeamChange(value: string) {
+  if (value) {
+    router.push(`/goalie-stats/${value}`)
+  }
+}
+
+function onSortChange(column: SortColumn, direction: SortDirection) {
+  sortBy.value = column
+  sortOrder.value = direction
+}
+
+useHead({
+  title: 'Goalie Stats'
+})
+</script>

--- a/tests/nuxt/components/GoalieStatsTable.nuxt.test.ts
+++ b/tests/nuxt/components/GoalieStatsTable.nuxt.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { ref } from 'vue'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import GoalieStatsTable from '~/components/GoalieStatsTable.vue'
 import type { GoalieStatsWithTeam } from '~/types/goalies'
 import type { Team } from '~/types/teams'
@@ -43,14 +43,12 @@ const mockGoalie = (overrides: Partial<GoalieStatsWithTeam> = {}): GoalieStatsWi
   ...overrides
 })
 
-vi.mock('better-convex-nuxt', () => ({
-  useConvexQuery: () => ({
-    data: ref([
-      mockTeam({ short_name: 'TOR', city: 'Toronto', name: 'Maple Leafs' }),
-      mockTeam({ short_name: 'MTL', city: 'Montreal', name: 'Canadiens' }),
-      mockTeam({ short_name: 'NYR', city: 'New York', name: 'Rangers' }),
-    ])
-  })
+mockNuxtImport('useConvexQuery', () => () => ({
+  data: ref([
+    mockTeam({ short_name: 'TOR', city: 'Toronto', name: 'Maple Leafs' }),
+    mockTeam({ short_name: 'MTL', city: 'Montreal', name: 'Canadiens' }),
+    mockTeam({ short_name: 'NYR', city: 'New York', name: 'Rangers' }),
+  ])
 }))
 
 describe('GoalieStatsTable', () => {

--- a/tests/nuxt/components/GoalieStatsTable.nuxt.test.ts
+++ b/tests/nuxt/components/GoalieStatsTable.nuxt.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ref } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import GoalieStatsTable from '~/components/GoalieStatsTable.vue'
+import type { GoalieStatsWithTeam } from '~/types/goalies'
+import type { Team } from '~/types/teams'
+
+const mockTeam = (overrides: Partial<Team> = {}): Team => ({
+  _id: 'team123' as unknown as Team['_id'],
+  _creationTime: Date.now(),
+  short_name: 'TOR',
+  city: 'Toronto',
+  name: 'Maple Leafs',
+  year: 2026,
+  division_id: 'div123' as unknown as Team['division_id'],
+  ...overrides
+})
+
+const mockGoalie = (overrides: Partial<GoalieStatsWithTeam> = {}): GoalieStatsWithTeam => ({
+  _id: 'goalie123' as unknown as GoalieStatsWithTeam['_id'],
+  _creationTime: Date.now(),
+  playerId: 1,
+  firstName: 'Jonathan',
+  lastName: 'Quick',
+  searchName: 'jonathan quick',
+  year: 2026,
+  gamesPlayed: 45,
+  gamesStarted: 44,
+  wins: 28,
+  losses: 12,
+  otLosses: 5,
+  shotsAgainst: 1200,
+  goalsAgainst: 95,
+  saves: 1105,
+  savePct: 0.921,
+  goalsAgainstAverage: 2.15,
+  shutouts: 4,
+  timeOnIce: 2650,
+  goals: 0,
+  assists: 2,
+  penaltyMinutes: 4,
+  team: mockTeam(),
+  ...overrides
+})
+
+vi.mock('better-convex-nuxt', () => ({
+  useConvexQuery: () => ({
+    data: ref([
+      mockTeam({ short_name: 'TOR', city: 'Toronto', name: 'Maple Leafs' }),
+      mockTeam({ short_name: 'MTL', city: 'Montreal', name: 'Canadiens' }),
+      mockTeam({ short_name: 'NYR', city: 'New York', name: 'Rangers' }),
+    ])
+  })
+}))
+
+describe('GoalieStatsTable', () => {
+  it('renders goalie list', async () => {
+    const goalies = [
+      mockGoalie({ firstName: 'Igor', lastName: 'Shesterkin', wins: 35, savePct: 0.925 }),
+      mockGoalie({ firstName: 'Jonathan', lastName: 'Quick', wins: 28, savePct: 0.921 }),
+      mockGoalie({ firstName: 'Carey', lastName: 'Price', wins: 22, savePct: 0.905 }),
+    ]
+
+    const component = await mountSuspended(GoalieStatsTable, {
+      props: {
+        goalies,
+        selectedTeamShortName: '',
+        sortBy: 'wins',
+        sortOrder: 'desc',
+        onTeamChange: vi.fn(),
+        onSortChange: vi.fn(),
+      }
+    })
+
+    expect(component.html()).toMatchSnapshot()
+  })
+
+  it('renders filtered by team', async () => {
+    const goalies = [
+      mockGoalie({
+        firstName: 'Igor',
+        lastName: 'Shesterkin',
+        team: mockTeam({ short_name: 'NYR', city: 'New York', name: 'Rangers' })
+      }),
+      mockGoalie({
+        firstName: 'Jonathan',
+        lastName: 'Quick',
+        team: mockTeam({ short_name: 'NYR', city: 'New York', name: 'Rangers' })
+      }),
+    ]
+
+    const component = await mountSuspended(GoalieStatsTable, {
+      props: {
+        goalies,
+        selectedTeamShortName: 'NYR',
+        sortBy: 'wins',
+        sortOrder: 'desc',
+        onTeamChange: vi.fn(),
+        onSortChange: vi.fn(),
+      }
+    })
+
+    expect(component.html()).toMatchSnapshot()
+  })
+
+  it('renders with search query', async () => {
+    const goalies = [
+      mockGoalie({ firstName: 'Igor', lastName: 'Shesterkin', wins: 35 }),
+    ]
+
+    const component = await mountSuspended(GoalieStatsTable, {
+      props: {
+        goalies,
+        selectedTeamShortName: '',
+        sortBy: 'wins',
+        sortOrder: 'desc',
+        onTeamChange: vi.fn(),
+        onSortChange: vi.fn(),
+        searchQuery: 'shesterkin',
+      }
+    })
+
+    expect(component.html()).toMatchSnapshot()
+  })
+
+  it('renders empty state', async () => {
+    const component = await mountSuspended(GoalieStatsTable, {
+      props: {
+        goalies: [],
+        selectedTeamShortName: '',
+        sortBy: 'wins',
+        sortOrder: 'desc',
+        onTeamChange: vi.fn(),
+        onSortChange: vi.fn(),
+      }
+    })
+
+    expect(component.html()).toMatchSnapshot()
+  })
+
+  it('renders with GAA sort ascending (lower is better)', async () => {
+    const goalies = [
+      mockGoalie({ firstName: 'Igor', lastName: 'Shesterkin', goalsAgainstAverage: 2.15 }),
+      mockGoalie({ firstName: 'Jonathan', lastName: 'Quick', goalsAgainstAverage: 2.45 }),
+    ]
+
+    const component = await mountSuspended(GoalieStatsTable, {
+      props: {
+        goalies,
+        selectedTeamShortName: '',
+        sortBy: 'goalsAgainstAverage',
+        sortOrder: 'asc',
+        onTeamChange: vi.fn(),
+        onSortChange: vi.fn(),
+      }
+    })
+
+    expect(component.html()).toMatchSnapshot()
+  })
+
+  it('renders with save percentage sort', async () => {
+    const goalies = [
+      mockGoalie({ firstName: 'Igor', lastName: 'Shesterkin', savePct: 0.925 }),
+      mockGoalie({ firstName: 'Jonathan', lastName: 'Quick', savePct: 0.921 }),
+    ]
+
+    const component = await mountSuspended(GoalieStatsTable, {
+      props: {
+        goalies,
+        selectedTeamShortName: '',
+        sortBy: 'savePct',
+        sortOrder: 'desc',
+        onTeamChange: vi.fn(),
+        onSortChange: vi.fn(),
+      }
+    })
+
+    expect(component.html()).toMatchSnapshot()
+  })
+})

--- a/tests/nuxt/components/__snapshots__/GoalieStatsTable.nuxt.test.ts.snap
+++ b/tests/nuxt/components/__snapshots__/GoalieStatsTable.nuxt.test.ts.snap
@@ -5,6 +5,9 @@ exports[`GoalieStatsTable > renders empty state 1`] = `
   <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
     <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="">
         <option value="">All Teams</option>
+        <option value="MTL">Montreal Canadiens</option>
+        <option value="NYR">New York Rangers</option>
+        <option value="TOR">Toronto Maple Leafs</option>
       </select></div>
     <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
   </div>
@@ -37,6 +40,9 @@ exports[`GoalieStatsTable > renders filtered by team 1`] = `
   <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
     <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="NYR">
         <option value="">All Teams</option>
+        <option value="MTL">Montreal Canadiens</option>
+        <option value="NYR">New York Rangers</option>
+        <option value="TOR">Toronto Maple Leafs</option>
       </select></div>
     <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
   </div>
@@ -102,6 +108,9 @@ exports[`GoalieStatsTable > renders goalie list 1`] = `
   <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
     <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="">
         <option value="">All Teams</option>
+        <option value="MTL">Montreal Canadiens</option>
+        <option value="NYR">New York Rangers</option>
+        <option value="TOR">Toronto Maple Leafs</option>
       </select></div>
     <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
   </div>
@@ -183,6 +192,9 @@ exports[`GoalieStatsTable > renders with GAA sort ascending (lower is better) 1`
   <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
     <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="">
         <option value="">All Teams</option>
+        <option value="MTL">Montreal Canadiens</option>
+        <option value="NYR">New York Rangers</option>
+        <option value="TOR">Toronto Maple Leafs</option>
       </select></div>
     <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
   </div>
@@ -248,6 +260,9 @@ exports[`GoalieStatsTable > renders with save percentage sort 1`] = `
   <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
     <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="">
         <option value="">All Teams</option>
+        <option value="MTL">Montreal Canadiens</option>
+        <option value="NYR">New York Rangers</option>
+        <option value="TOR">Toronto Maple Leafs</option>
       </select></div>
     <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
   </div>
@@ -313,6 +328,9 @@ exports[`GoalieStatsTable > renders with search query 1`] = `
   <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
     <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="">
         <option value="">All Teams</option>
+        <option value="MTL">Montreal Canadiens</option>
+        <option value="NYR">New York Rangers</option>
+        <option value="TOR">Toronto Maple Leafs</option>
       </select></div>
     <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
   </div>

--- a/tests/nuxt/components/__snapshots__/GoalieStatsTable.nuxt.test.ts.snap
+++ b/tests/nuxt/components/__snapshots__/GoalieStatsTable.nuxt.test.ts.snap
@@ -1,0 +1,358 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GoalieStatsTable > renders empty state 1`] = `
+"<div>
+  <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
+    <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="">
+        <option value="">All Teams</option>
+      </select></div>
+    <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
+  </div>
+  <table class="w-4/5 m-auto text-white">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Team</th>
+        <th>Goalie</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GP </th>
+        <th>GS</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> W ↓</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> L </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> OTL </th>
+        <th>SA</th>
+        <th>GA</th>
+        <th>SV</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SV% </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GAA </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SO </th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</div>"
+`;
+
+exports[`GoalieStatsTable > renders filtered by team 1`] = `
+"<div>
+  <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
+    <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="NYR">
+        <option value="">All Teams</option>
+      </select></div>
+    <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
+  </div>
+  <table class="w-4/5 m-auto text-white">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Team</th>
+        <th>Goalie</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GP </th>
+        <th>GS</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> W ↓</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> L </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> OTL </th>
+        <th>SA</th>
+        <th>GA</th>
+        <th>SV</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SV% </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GAA </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SO </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="even:bg-zinc-600 text-center">
+        <td class="py-2 text-lg font-bold">1</td>
+        <td class="py-2"><a href="/goalie-stats/NYR"><img src="/logos/SVG/NYR.svg" class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform" alt="New York Rangers" title="Click to filter by New York Rangers"></a></td>
+        <td class="py-2">Igor Shesterkin</td>
+        <td class="py-2">45</td>
+        <td class="py-2">44</td>
+        <td class="py-2 font-semibold">28</td>
+        <td class="py-2">12</td>
+        <td class="py-2">5</td>
+        <td class="py-2">1200</td>
+        <td class="py-2">95</td>
+        <td class="py-2">1105</td>
+        <td class="py-2">92.1%</td>
+        <td class="py-2">2.15</td>
+        <td class="py-2">4</td>
+      </tr>
+      <tr class="even:bg-zinc-600 text-center">
+        <td class="py-2 text-lg font-bold">2</td>
+        <td class="py-2"><a href="/goalie-stats/NYR"><img src="/logos/SVG/NYR.svg" class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform" alt="New York Rangers" title="Click to filter by New York Rangers"></a></td>
+        <td class="py-2">Jonathan Quick</td>
+        <td class="py-2">45</td>
+        <td class="py-2">44</td>
+        <td class="py-2 font-semibold">28</td>
+        <td class="py-2">12</td>
+        <td class="py-2">5</td>
+        <td class="py-2">1200</td>
+        <td class="py-2">95</td>
+        <td class="py-2">1105</td>
+        <td class="py-2">92.1%</td>
+        <td class="py-2">2.15</td>
+        <td class="py-2">4</td>
+      </tr>
+    </tbody>
+  </table>
+</div>"
+`;
+
+exports[`GoalieStatsTable > renders goalie list 1`] = `
+"<div>
+  <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
+    <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="">
+        <option value="">All Teams</option>
+      </select></div>
+    <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
+  </div>
+  <table class="w-4/5 m-auto text-white">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Team</th>
+        <th>Goalie</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GP </th>
+        <th>GS</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> W ↓</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> L </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> OTL </th>
+        <th>SA</th>
+        <th>GA</th>
+        <th>SV</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SV% </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GAA </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SO </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="even:bg-zinc-600 text-center">
+        <td class="py-2 text-lg font-bold">1</td>
+        <td class="py-2"><a href="/goalie-stats/TOR"><img src="/logos/SVG/TOR.svg" class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform" alt="Toronto Maple Leafs" title="Click to filter by Toronto Maple Leafs"></a></td>
+        <td class="py-2">Igor Shesterkin</td>
+        <td class="py-2">45</td>
+        <td class="py-2">44</td>
+        <td class="py-2 font-semibold">35</td>
+        <td class="py-2">12</td>
+        <td class="py-2">5</td>
+        <td class="py-2">1200</td>
+        <td class="py-2">95</td>
+        <td class="py-2">1105</td>
+        <td class="py-2">92.5%</td>
+        <td class="py-2">2.15</td>
+        <td class="py-2">4</td>
+      </tr>
+      <tr class="even:bg-zinc-600 text-center">
+        <td class="py-2 text-lg font-bold">2</td>
+        <td class="py-2"><a href="/goalie-stats/TOR"><img src="/logos/SVG/TOR.svg" class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform" alt="Toronto Maple Leafs" title="Click to filter by Toronto Maple Leafs"></a></td>
+        <td class="py-2">Jonathan Quick</td>
+        <td class="py-2">45</td>
+        <td class="py-2">44</td>
+        <td class="py-2 font-semibold">28</td>
+        <td class="py-2">12</td>
+        <td class="py-2">5</td>
+        <td class="py-2">1200</td>
+        <td class="py-2">95</td>
+        <td class="py-2">1105</td>
+        <td class="py-2">92.1%</td>
+        <td class="py-2">2.15</td>
+        <td class="py-2">4</td>
+      </tr>
+      <tr class="even:bg-zinc-600 text-center">
+        <td class="py-2 text-lg font-bold">3</td>
+        <td class="py-2"><a href="/goalie-stats/TOR"><img src="/logos/SVG/TOR.svg" class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform" alt="Toronto Maple Leafs" title="Click to filter by Toronto Maple Leafs"></a></td>
+        <td class="py-2">Carey Price</td>
+        <td class="py-2">45</td>
+        <td class="py-2">44</td>
+        <td class="py-2 font-semibold">22</td>
+        <td class="py-2">12</td>
+        <td class="py-2">5</td>
+        <td class="py-2">1200</td>
+        <td class="py-2">95</td>
+        <td class="py-2">1105</td>
+        <td class="py-2">90.5%</td>
+        <td class="py-2">2.15</td>
+        <td class="py-2">4</td>
+      </tr>
+    </tbody>
+  </table>
+</div>"
+`;
+
+exports[`GoalieStatsTable > renders with GAA sort ascending (lower is better) 1`] = `
+"<div>
+  <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
+    <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="">
+        <option value="">All Teams</option>
+      </select></div>
+    <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
+  </div>
+  <table class="w-4/5 m-auto text-white">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Team</th>
+        <th>Goalie</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GP </th>
+        <th>GS</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> W </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> L </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> OTL </th>
+        <th>SA</th>
+        <th>GA</th>
+        <th>SV</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SV% </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GAA ↑</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SO </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="even:bg-zinc-600 text-center">
+        <td class="py-2 text-lg font-bold">1</td>
+        <td class="py-2"><a href="/goalie-stats/TOR"><img src="/logos/SVG/TOR.svg" class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform" alt="Toronto Maple Leafs" title="Click to filter by Toronto Maple Leafs"></a></td>
+        <td class="py-2">Igor Shesterkin</td>
+        <td class="py-2">45</td>
+        <td class="py-2">44</td>
+        <td class="py-2 font-semibold">28</td>
+        <td class="py-2">12</td>
+        <td class="py-2">5</td>
+        <td class="py-2">1200</td>
+        <td class="py-2">95</td>
+        <td class="py-2">1105</td>
+        <td class="py-2">92.1%</td>
+        <td class="py-2">2.15</td>
+        <td class="py-2">4</td>
+      </tr>
+      <tr class="even:bg-zinc-600 text-center">
+        <td class="py-2 text-lg font-bold">2</td>
+        <td class="py-2"><a href="/goalie-stats/TOR"><img src="/logos/SVG/TOR.svg" class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform" alt="Toronto Maple Leafs" title="Click to filter by Toronto Maple Leafs"></a></td>
+        <td class="py-2">Jonathan Quick</td>
+        <td class="py-2">45</td>
+        <td class="py-2">44</td>
+        <td class="py-2 font-semibold">28</td>
+        <td class="py-2">12</td>
+        <td class="py-2">5</td>
+        <td class="py-2">1200</td>
+        <td class="py-2">95</td>
+        <td class="py-2">1105</td>
+        <td class="py-2">92.1%</td>
+        <td class="py-2">2.45</td>
+        <td class="py-2">4</td>
+      </tr>
+    </tbody>
+  </table>
+</div>"
+`;
+
+exports[`GoalieStatsTable > renders with save percentage sort 1`] = `
+"<div>
+  <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
+    <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="">
+        <option value="">All Teams</option>
+      </select></div>
+    <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
+  </div>
+  <table class="w-4/5 m-auto text-white">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Team</th>
+        <th>Goalie</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GP </th>
+        <th>GS</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> W </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> L </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> OTL </th>
+        <th>SA</th>
+        <th>GA</th>
+        <th>SV</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SV% ↓</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GAA </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SO </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="even:bg-zinc-600 text-center">
+        <td class="py-2 text-lg font-bold">1</td>
+        <td class="py-2"><a href="/goalie-stats/TOR"><img src="/logos/SVG/TOR.svg" class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform" alt="Toronto Maple Leafs" title="Click to filter by Toronto Maple Leafs"></a></td>
+        <td class="py-2">Igor Shesterkin</td>
+        <td class="py-2">45</td>
+        <td class="py-2">44</td>
+        <td class="py-2 font-semibold">28</td>
+        <td class="py-2">12</td>
+        <td class="py-2">5</td>
+        <td class="py-2">1200</td>
+        <td class="py-2">95</td>
+        <td class="py-2">1105</td>
+        <td class="py-2">92.5%</td>
+        <td class="py-2">2.15</td>
+        <td class="py-2">4</td>
+      </tr>
+      <tr class="even:bg-zinc-600 text-center">
+        <td class="py-2 text-lg font-bold">2</td>
+        <td class="py-2"><a href="/goalie-stats/TOR"><img src="/logos/SVG/TOR.svg" class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform" alt="Toronto Maple Leafs" title="Click to filter by Toronto Maple Leafs"></a></td>
+        <td class="py-2">Jonathan Quick</td>
+        <td class="py-2">45</td>
+        <td class="py-2">44</td>
+        <td class="py-2 font-semibold">28</td>
+        <td class="py-2">12</td>
+        <td class="py-2">5</td>
+        <td class="py-2">1200</td>
+        <td class="py-2">95</td>
+        <td class="py-2">1105</td>
+        <td class="py-2">92.1%</td>
+        <td class="py-2">2.15</td>
+        <td class="py-2">4</td>
+      </tr>
+    </tbody>
+  </table>
+</div>"
+`;
+
+exports[`GoalieStatsTable > renders with search query 1`] = `
+"<div>
+  <div class="w-4/5 mx-auto mb-4 flex items-center justify-between">
+    <div class="flex items-center gap-4"><label for="team-filter" class="text-white font-semibold">Filter by Team:</label><select id="team-filter" class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500" value="">
+        <option value="">All Teams</option>
+      </select></div>
+    <div class="flex items-center gap-4"><label for="goalie-search" class="sr-only">Search goalies</label><input id="goalie-search" type="text" placeholder="Search goalies..." class="bg-zinc-700 text-white px-4 py-2 rounded-lg border border-zinc-600 focus:outline-none focus:border-blue-500 w-64 placeholder-zinc-400"></div>
+  </div>
+  <table class="w-4/5 m-auto text-white">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Team</th>
+        <th>Goalie</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GP </th>
+        <th>GS</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> W ↓</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> L </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> OTL </th>
+        <th>SA</th>
+        <th>GA</th>
+        <th>SV</th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SV% </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> GAA </th>
+        <th class="cursor-pointer hover:text-blue-400 select-none"> SO </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="even:bg-zinc-600 text-center">
+        <td class="py-2 text-lg font-bold">1</td>
+        <td class="py-2"><a href="/goalie-stats/TOR"><img src="/logos/SVG/TOR.svg" class="h-10 mx-auto cursor-pointer hover:scale-110 transition-transform" alt="Toronto Maple Leafs" title="Click to filter by Toronto Maple Leafs"></a></td>
+        <td class="py-2">Igor Shesterkin</td>
+        <td class="py-2">45</td>
+        <td class="py-2">44</td>
+        <td class="py-2 font-semibold">35</td>
+        <td class="py-2">12</td>
+        <td class="py-2">5</td>
+        <td class="py-2">1200</td>
+        <td class="py-2">95</td>
+        <td class="py-2">1105</td>
+        <td class="py-2">92.1%</td>
+        <td class="py-2">2.15</td>
+        <td class="py-2">4</td>
+      </tr>
+    </tbody>
+  </table>
+</div>"
+`;

--- a/tests/visual/goalie-stats.spec.ts
+++ b/tests/visual/goalie-stats.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Goalie Stats Pages Visual Regression', () => {
+  test('goalie stats list page', async ({ page }) => {
+    await page.goto('/goalie-stats')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('table tbody tr').first()).toBeVisible()
+    await expect(page).toHaveScreenshot('goalie-stats-list.png', {
+      fullPage: true
+    })
+  })
+
+  test('goalie stats filtered by team', async ({ page }) => {
+    await page.goto('/goalie-stats/TOR')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('table tbody tr').first()).toBeVisible()
+    await expect(page).toHaveScreenshot('goalie-stats-team-filter.png', {
+      fullPage: true
+    })
+  })
+
+  test('goalie stats with search', async ({ page }) => {
+    await page.goto('/goalie-stats')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('table tbody tr').first()).toBeVisible()
+
+    const searchInput = page.locator('input[placeholder="Search goalies..."]')
+    await searchInput.fill('shesterkin')
+    await expect(page.locator('table tbody tr')).toHaveCount(1)
+
+    await expect(page).toHaveScreenshot('goalie-stats-search.png', {
+      fullPage: true
+    })
+  })
+
+  test('goalie stats team page with search', async ({ page }) => {
+    await page.goto('/goalie-stats/NYR')
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('table tbody tr').first()).toBeVisible()
+
+    const searchInput = page.locator('input[placeholder="Search goalies..."]')
+    await searchInput.fill('quick')
+    await expect(page.locator('table tbody tr')).toHaveCount(1)
+
+    await expect(page).toHaveScreenshot('goalie-stats-team-search.png', {
+      fullPage: true
+    })
+  })
+})

--- a/tests/visual/goalie-stats.spec.ts-snapshots/goalie-stats-list-chromium-linux.png
+++ b/tests/visual/goalie-stats.spec.ts-snapshots/goalie-stats-list-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b37c43d341cb063abb4ebefc7de8e0b7464b3a805a339a72564bf8709137393e
+size 914033

--- a/tests/visual/goalie-stats.spec.ts-snapshots/goalie-stats-search-chromium-linux.png
+++ b/tests/visual/goalie-stats.spec.ts-snapshots/goalie-stats-search-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ec91449084807ec5ee41fd42f24da85f59aaffb6b56d401d698e318e36120d8
+size 38072

--- a/tests/visual/goalie-stats.spec.ts-snapshots/goalie-stats-team-filter-chromium-linux.png
+++ b/tests/visual/goalie-stats.spec.ts-snapshots/goalie-stats-team-filter-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6b04f093a75e75ca335a031df250b46cc5eda66a4b3f0a5a5275065aaa312c8
+size 66883

--- a/tests/visual/goalie-stats.spec.ts-snapshots/goalie-stats-team-search-chromium-linux.png
+++ b/tests/visual/goalie-stats.spec.ts-snapshots/goalie-stats-team-search-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b723629e4bed72dc35c755f1e8a3a73e764d6d822f27f1f1cc2d72449e8bbacc
+size 38571

--- a/types/goalies.ts
+++ b/types/goalies.ts
@@ -1,0 +1,8 @@
+import type { Doc } from "../convex/_generated/dataModel";
+import type { Team } from "./teams";
+
+export type GoalieStats = Doc<"goalieStats">;
+
+export interface GoalieStatsWithTeam extends Omit<GoalieStats, "team_id"> {
+  team?: Team | null;
+}


### PR DESCRIPTION
- Add goalieStats table to schema with full stats (GP, GS, W, L, OTL, SA, GA, SV, SV%, GAA, SO, etc.)
- Create convex/goalieStats.ts with queries, search, and NHL API sync
- Add daily cron job for goalie stats sync
- Create GoalieStatsTable.vue component with sortable columns
- Create goalie-stats pages (index and team-filtered)
- Add Goalie Stats to main navigation
- Add types/goalies.ts for type definitions
- Add comprehensive tests for GoalieStatsTable component
- Add visual regression tests for goalie stats pages
- Cleanup unused functions from playerStats.ts and goalieStats.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Goalie Stats pages and table with sortable columns, team filtering, and goalie search.
  * Site navigation link for Goalie Stats.
  * Automatic daily NHL goalie data synchronization.

* **Tests**
  * Added component unit tests and visual regression tests for Goalie Stats pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->