### PR TITLE
Add more MCP tools beyond the existing nhl-standings:

### DIFF
--- a/convex/playerStats.ts
+++ b/convex/playerStats.ts
@@ -47,6 +47,7 @@ export const getPlayerStatsWithTeamsByTeamSorted = query({
       v.literal("shootingPct")
     ),
     sortOrder: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
+    limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const playerStats = await ctx.db
@@ -65,9 +66,11 @@ export const getPlayerStatsWithTeamsByTeamSorted = query({
       return order === "asc" ? aValue - bValue : bValue - aValue;
     });
 
+    const limitedStats = args.limit ? sortedStats.slice(0, args.limit) : sortedStats;
+
     const team = await ctx.db.get(args.teamId);
 
-    return sortedStats.map((stat) => ({
+    return limitedStats.map((stat) => ({
       ...stat,
       team,
     }));
@@ -155,6 +158,34 @@ export const getPlayerStatsWithTeamsSorted = query({
         team,
       };
     });
+  },
+});
+
+export const getPlayerById = query({
+  args: {
+    playerId: v.number(),
+    year: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const playerYear = args.year ?? 2026;
+
+    const playerStat = await ctx.db
+      .query("playerStats")
+      .withIndex("year_playerId", (q) =>
+        q.eq("year", playerYear).eq("playerId", args.playerId)
+      )
+      .first();
+
+    if (!playerStat) {
+      return null;
+    }
+
+    const team = await ctx.db.get(playerStat.team_id);
+
+    return {
+      ...playerStat,
+      team,
+    };
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -21,7 +21,8 @@ export default defineSchema({
     division_id: v.optional(v.id("divisions")),
   })
     .index("by_division_id", ["division_id"])
-    .index("by_short_name", ["short_name"]),
+    .index("by_short_name", ["short_name"])
+    .index("by_year_short_name", ["year", "short_name"]),
 
   divisions: defineTable({
     name: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -19,7 +19,9 @@ export default defineSchema({
     name: v.string(),
     year: v.number(),
     division_id: v.optional(v.id("divisions")),
-  }).index("by_division_id", ["division_id"]),
+  })
+    .index("by_division_id", ["division_id"])
+    .index("by_short_name", ["short_name"]),
 
   divisions: defineTable({
     name: v.string(),

--- a/convex/teams.ts
+++ b/convex/teams.ts
@@ -1,4 +1,5 @@
 import { query } from "./_generated/server";
+import { v } from "convex/values";
 
 export const getTeams = query({
   args: {},
@@ -33,5 +34,55 @@ export const getDivisions = query({
   handler: async (ctx) => {
     const divisions = await ctx.db.query("divisions").collect();
     return divisions;
+  },
+});
+
+export const getTeamByShortName = query({
+  args: { shortName: v.string() },
+  handler: async (ctx, args) => {
+    const team = await ctx.db
+      .query("teams")
+      .withIndex("by_short_name", (q) => q.eq("short_name", args.shortName))
+      .first();
+    return team;
+  },
+});
+
+export const getTeamsByConference = query({
+  args: { conference: v.optional(v.string()) },
+  handler: async (ctx, args) => {
+    let teams = await ctx.db.query("teams").collect();
+
+    if (args.conference) {
+      const divisions = await ctx.db.query("divisions").collect();
+      const divisionIds = divisions
+        .filter((d) => d.conference === args.conference)
+        .map((d) => d._id.toString());
+
+      teams = teams.filter((t) =>
+        t.division_id && divisionIds.includes(t.division_id.toString())
+      );
+    }
+
+    return teams;
+  },
+});
+
+export const getTeamsByDivisionName = query({
+  args: { division: v.string() },
+  handler: async (ctx, args) => {
+    const divisions = await ctx.db.query("divisions").collect();
+    const division = divisions.find((d) => d.name === args.division);
+
+    if (!division) {
+      return [];
+    }
+
+    const teams = await ctx.db
+      .query("teams")
+      .withIndex("by_division_id", (q) => q.eq("division_id", division._id))
+      .collect();
+
+    return teams;
   },
 });

--- a/pages/mcp.vue
+++ b/pages/mcp.vue
@@ -60,17 +60,67 @@
       </div>
     </div>
 
-    <!-- Info Section -->
-    <div class="bg-zinc-700 rounded-lg shadow-md p-8">
-      <h2 class="text-2xl font-bold mb-4 text-white">What You Get</h2>
+    <!-- Tools Section -->
+    <div class="bg-zinc-700 rounded-lg shadow-md p-8 mb-8">
+      <h2 class="text-2xl font-bold mb-4 text-white">Available Tools</h2>
       <p class="text-zinc-300 mb-4">
-        This MCP server provides access to comprehensive NHL statistics including:
+        This MCP server provides access to comprehensive NHL statistics through the following tools:
       </p>
-      <ul class="list-disc list-inside text-zinc-300 space-y-2">
-        <li>Current season standings</li>
-      </ul>
-      <div class="text-zinc-300 mt-4">
+
+      <div class="space-y-4">
+        <div class="border-l-4 border-zinc-500 pl-4">
+          <h3 class="font-semibold text-white">nhl-standings</h3>
+          <p class="text-zinc-300 text-sm">Get NHL standings for a given year</p>
+          <p class="text-zinc-400 text-xs mt-1">Parameters: year (number)</p>
+        </div>
+
+        <div class="border-l-4 border-zinc-500 pl-4">
+          <h3 class="font-semibold text-white">nhl-player-stats</h3>
+          <p class="text-zinc-300 text-sm">Get player statistics with filtering options</p>
+          <p class="text-zinc-400 text-xs mt-1">Parameters: year (optional), team (optional), sortBy (optional: points, goals, assists), limit (optional, default 50, max 100)</p>
+        </div>
+
+        <div class="border-l-4 border-zinc-500 pl-4">
+          <h3 class="font-semibold text-white">nhl-team-info</h3>
+          <p class="text-zinc-300 text-sm">Get detailed information about a specific team including standings and all players</p>
+          <p class="text-zinc-400 text-xs mt-1">Parameters: team (required, short name like "MTL"), year (optional)</p>
+        </div>
+
+        <div class="border-l-4 border-zinc-500 pl-4">
+          <h3 class="font-semibold text-white">nhl-player-details</h3>
+          <p class="text-zinc-300 text-sm">Get detailed stats for a specific player by ID</p>
+          <p class="text-zinc-400 text-xs mt-1">Parameters: playerId (required), year (optional)</p>
+        </div>
+
+        <div class="border-l-4 border-zinc-500 pl-4">
+          <h3 class="font-semibold text-white">nhl-player-search</h3>
+          <p class="text-zinc-300 text-sm">Search for NHL players by name with optional team filtering</p>
+          <p class="text-zinc-400 text-xs mt-1">Parameters: query (required), team (optional), year (optional), limit (optional, default 20, max 50)</p>
+        </div>
+
+        <div class="border-l-4 border-zinc-500 pl-4">
+          <h3 class="font-semibold text-white">nhl-teams-list</h3>
+          <p class="text-zinc-300 text-sm">Get list of all NHL teams with optional filtering</p>
+          <p class="text-zinc-400 text-xs mt-1">Parameters: conference (optional: EAST, WEST), division (optional)</p>
+        </div>
+      </div>
+
+      <div class="text-zinc-300 mt-6 text-sm">
         Your MCP client will automatically discover and present available tools.
+      </div>
+    </div>
+
+    <!-- Example Queries -->
+    <div class="bg-zinc-700 rounded-lg shadow-md p-8">
+      <h2 class="text-2xl font-bold mb-4 text-white">Example Queries</h2>
+      <div class="space-y-3 text-zinc-300 text-sm">
+        <p>"What are the current NHL standings?"</p>
+        <p>"Show me the top 10 goal scorers this season"</p>
+        <p>"List all teams in the Eastern Conference"</p>
+        <p>"Tell me about the Toronto Maple Leafs"</p>
+        <p>"Get player stats for the Canadiens sorted by goals"</p>
+        <p>"Search for players named Connor"</p>
+        <p>"Find all players on the Oilers named McDavid"</p>
       </div>
     </div>
   </div>

--- a/server/mcp/prompts/get-player-details.ts
+++ b/server/mcp/prompts/get-player-details.ts
@@ -1,0 +1,15 @@
+export default defineMcpPrompt({
+  name: 'get-player-details',
+  description: 'Get detailed statistics for a specific NHL player',
+  handler: async () => {
+    return {
+      messages: [{
+        role: 'user',
+        content: {
+          type: 'text',
+          text: 'Show me detailed stats for Connor McDavid'
+        }
+      }]
+    }
+  }
+})

--- a/server/mcp/prompts/get-player-stats.ts
+++ b/server/mcp/prompts/get-player-stats.ts
@@ -1,0 +1,15 @@
+export default defineMcpPrompt({
+  name: 'get-player-stats',
+  description: 'Get NHL player statistics for a season',
+  handler: async () => {
+    return {
+      messages: [{
+        role: 'user',
+        content: {
+          type: 'text',
+          text: 'Show me the top NHL players by points for this season'
+        }
+      }]
+    }
+  }
+})

--- a/server/mcp/prompts/get-team-info.ts
+++ b/server/mcp/prompts/get-team-info.ts
@@ -1,0 +1,15 @@
+export default defineMcpPrompt({
+  name: 'get-team-info',
+  description: 'Get detailed information about an NHL team',
+  handler: async () => {
+    return {
+      messages: [{
+        role: 'user',
+        content: {
+          type: 'text',
+          text: 'Tell me about the Montreal Canadiens team stats and standings'
+        }
+      }]
+    }
+  }
+})

--- a/server/mcp/prompts/get-teams-list.ts
+++ b/server/mcp/prompts/get-teams-list.ts
@@ -1,0 +1,15 @@
+export default defineMcpPrompt({
+  name: 'get-teams-list',
+  description: 'Get list of all NHL teams',
+  handler: async () => {
+    return {
+      messages: [{
+        role: 'user',
+        content: {
+          type: 'text',
+          text: 'List all NHL teams'
+        }
+      }]
+    }
+  }
+})

--- a/server/mcp/prompts/search-players.ts
+++ b/server/mcp/prompts/search-players.ts
@@ -1,0 +1,15 @@
+export default defineMcpPrompt({
+  name: 'search-players',
+  description: 'Search for NHL players by name',
+  handler: async () => {
+    return {
+      messages: [{
+        role: 'user',
+        content: {
+          type: 'text',
+          text: 'Find players named Connor in the NHL'
+        }
+      }]
+    }
+  }
+})

--- a/server/mcp/tools/nhl-player-details.ts
+++ b/server/mcp/tools/nhl-player-details.ts
@@ -6,7 +6,7 @@ const DEFAULT_YEAR = 2026
 
 export default defineMcpTool({
   name: 'nhl-player-details',
-  description: 'Get detailed statistics for a specific NHL player',
+  description: 'Get detailed season statistics for a specific NHL player for a given year',
   inputSchema: {
     playerId: z.number().describe('NHL player ID (e.g., 8478402 for Connor McDavid)'),
     year: z.number().optional().describe('The season year (e.g., 2024, 2025, 2026). Defaults to current season')

--- a/server/mcp/tools/nhl-player-details.ts
+++ b/server/mcp/tools/nhl-player-details.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod'
+import { ConvexHttpClient } from 'convex/browser'
+import { api } from '~/convex/_generated/api'
+
+const DEFAULT_YEAR = 2026
+
+export default defineMcpTool({
+  name: 'nhl-player-details',
+  description: 'Get detailed statistics for a specific NHL player',
+  inputSchema: {
+    playerId: z.number().describe('NHL player ID (e.g., 8478402 for Connor McDavid)'),
+    year: z.number().optional().describe('The season year (e.g., 2024, 2025, 2026). Defaults to current season')
+  },
+  handler: async ({ playerId, year }) => {
+    const runtimeConfig = useRuntimeConfig()
+    const convexClient = new ConvexHttpClient(runtimeConfig.convex.url)
+
+    const targetYear = year ?? DEFAULT_YEAR
+
+    try {
+      const player = await convexClient.query(api.playerStats.getPlayerById, {
+        playerId,
+        year: targetYear
+      })
+
+      if (!player) {
+        return {
+          content: [{
+            type: 'text',
+            text: `Player with ID ${playerId} not found for season ${targetYear}. Please verify the player ID.`
+          }],
+          isError: true
+        }
+      }
+
+      const cleanPlayer = {
+        playerId: player.playerId,
+        name: `${player.firstName} ${player.lastName}`,
+        position: player.positionCode,
+        team: {
+          name: player.team?.name || '',
+          shortName: player.team?.short_name || '',
+          city: player.team?.city || '',
+        },
+        season: {
+          year: player.year,
+          gamesPlayed: player.gamesPlayed,
+          goals: player.goals,
+          assists: player.assists,
+          points: player.points,
+          plusMinus: player.plusMinus,
+          penaltyMinutes: player.penaltyMinutes,
+          shots: player.shots,
+          shootingPct: player.shootingPct,
+          timeOnIcePerGame: player.timeOnIcePerGame,
+          faceoffWinPct: player.faceoffWinPct,
+        },
+        scoring: {
+          goals: player.goals,
+          assists: player.assists,
+          points: player.points,
+          pointsPerGame: player.pointsPerGame,
+          gameWinningGoals: player.gameWinningGoals,
+          overtimeGoals: player.overtimeGoals,
+          powerPlayGoals: player.powerPlayGoals,
+          powerPlayPoints: player.powerPlayPoints,
+          shorthandedGoals: player.shorthandedGoals,
+          shorthandedPoints: player.shorthandedPoints,
+        },
+        advanced: {
+          shots: player.shots,
+          shootingPct: player.shootingPct,
+          timeOnIcePerGame: player.timeOnIcePerGame,
+          faceoffWinPct: player.faceoffWinPct,
+        },
+      }
+
+      return jsonResult(cleanPlayer, false)
+    } catch (error) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Error fetching player details for ID ${playerId}: ${error instanceof Error ? error.message : 'Unknown error'}`
+        }],
+        isError: true
+      }
+    }
+  }
+})

--- a/server/mcp/tools/nhl-player-search.ts
+++ b/server/mcp/tools/nhl-player-search.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod'
+import { ConvexHttpClient } from 'convex/browser'
+import { api } from '~/convex/_generated/api'
+
+const DEFAULT_LIMIT = 20
+const MAX_LIMIT = 50
+
+export default defineMcpTool({
+  name: 'nhl-player-search',
+  description: 'Search for NHL players by name with optional team filtering',
+  inputSchema: {
+    query: z.string().describe('Player name to search for (e.g., "Connor McDavid", "Ovechkin", "Sidney")'),
+    team: z.string().optional().describe('Team short name to filter by (e.g., "MTL", "TOR", "EDM")'),
+    year: z.number().optional().describe('The season year (e.g., 2024, 2025, 2026). Defaults to current season'),
+    limit: z.number().optional().describe('Number of results to return (default 20, max 50)')
+  },
+  handler: async ({ query, team, year, limit }) => {
+    const runtimeConfig = useRuntimeConfig()
+    const convexClient = new ConvexHttpClient(runtimeConfig.convex.url)
+
+    const targetYear = year ?? 2026
+    const targetLimit = Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT)
+
+    try {
+      let teamId = undefined
+
+      if (team) {
+        const teamData = await convexClient.query(api.teams.getTeamByShortName, { shortName: team.toUpperCase() })
+
+        if (!teamData) {
+          return {
+            content: [{
+              type: 'text',
+              text: `Team "${team}" not found. Please use a valid team short name (e.g., "MTL", "TOR", "EDM")`
+            }],
+            isError: true
+          }
+        }
+
+        teamId = teamData._id
+      }
+
+      const searchResults = await convexClient.query(api.playerStats.searchPlayers, {
+        query,
+        teamId,
+        limit: targetLimit
+      })
+
+      // Filter by year if specified (client-side filtering since search index doesn't support year)
+      const filteredResults = searchResults.filter((stat) => stat.year === targetYear)
+
+      const cleanResults = filteredResults.map((stat) => ({
+        playerId: stat.playerId,
+        name: `${stat.firstName} ${stat.lastName}`,
+        position: stat.positionCode,
+        team: {
+          name: stat.team?.name || '',
+          shortName: stat.team?.short_name || '',
+        },
+        year: stat.year,
+        gamesPlayed: stat.gamesPlayed,
+        goals: stat.goals,
+        assists: stat.assists,
+        points: stat.points,
+      }))
+
+      return jsonResult({
+        query,
+        team: team || null,
+        total: cleanResults.length,
+        players: cleanResults
+      }, false)
+    } catch (error) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Error searching for players: ${error instanceof Error ? error.message : 'Unknown error'}`
+        }],
+        isError: true
+      }
+    }
+  }
+})

--- a/server/mcp/tools/nhl-player-search.ts
+++ b/server/mcp/tools/nhl-player-search.ts
@@ -11,14 +11,12 @@ export default defineMcpTool({
   inputSchema: {
     query: z.string().describe('Player name to search for (e.g., "Connor McDavid", "Ovechkin", "Sidney")'),
     team: z.string().optional().describe('Team short name to filter by (e.g., "MTL", "TOR", "EDM")'),
-    year: z.number().optional().describe('The season year (e.g., 2024, 2025, 2026). Defaults to current season'),
     limit: z.number().optional().describe('Number of results to return (default 20, max 50)')
   },
-  handler: async ({ query, team, year, limit }) => {
+  handler: async ({ query, team, limit }) => {
     const runtimeConfig = useRuntimeConfig()
     const convexClient = new ConvexHttpClient(runtimeConfig.convex.url)
 
-    const targetYear = year ?? 2026
     const targetLimit = Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT)
 
     try {
@@ -46,10 +44,7 @@ export default defineMcpTool({
         limit: targetLimit
       })
 
-      // Filter by year if specified (client-side filtering since search index doesn't support year)
-      const filteredResults = searchResults.filter((stat) => stat.year === targetYear)
-
-      const cleanResults = filteredResults.map((stat) => ({
+      const cleanResults = searchResults.map((stat) => ({
         playerId: stat.playerId,
         name: `${stat.firstName} ${stat.lastName}`,
         position: stat.positionCode,

--- a/server/mcp/tools/nhl-player-stats.ts
+++ b/server/mcp/tools/nhl-player-stats.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod'
+import { ConvexHttpClient } from 'convex/browser'
+import { api } from '~/convex/_generated/api'
+
+const DEFAULT_YEAR = 2026
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 100
+
+export default defineMcpTool({
+  name: 'nhl-player-stats',
+  description: 'Get NHL player statistics with optional filtering by team and sorting',
+  inputSchema: {
+    year: z.number().optional().describe('The season year (e.g., 2024, 2025, 2026). Defaults to current season'),
+    team: z.string().optional().describe('Team short name to filter by (e.g., "MTL", "TOR", "NYR")'),
+    sortBy: z.enum(['points', 'goals', 'assists']).optional().describe('Sort players by: points, goals, or assists. Defaults to points'),
+    limit: z.number().optional().describe('Number of players to return (default 50, max 100)')
+  },
+  handler: async ({ year, team, sortBy, limit }) => {
+    const runtimeConfig = useRuntimeConfig()
+    const convexClient = new ConvexHttpClient(runtimeConfig.convex.url)
+
+    const targetYear = year ?? DEFAULT_YEAR
+    const targetSortBy = sortBy ?? 'points'
+    const targetLimit = Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT)
+
+    try {
+      let playerStats
+
+      if (team) {
+        const teamData = await convexClient.query(api.teams.getTeamByShortName, { shortName: team.toUpperCase() })
+
+        if (!teamData) {
+          return {
+            content: [{
+              type: 'text',
+              text: `Team "${team}" not found. Please use a valid team short name (e.g., "MTL", "TOR", "NYR")`
+            }],
+            isError: true
+          }
+        }
+
+        playerStats = await convexClient.query(api.playerStats.getPlayerStatsWithTeamsByTeamSorted, {
+          year: targetYear,
+          teamId: teamData._id,
+          sortBy: targetSortBy,
+          sortOrder: 'desc',
+          limit: targetLimit
+        })
+      } else {
+        playerStats = await convexClient.query(api.playerStats.getPlayerStatsWithTeamsSorted, {
+          year: targetYear,
+          sortBy: targetSortBy,
+          sortOrder: 'desc',
+          limit: targetLimit
+        })
+      }
+
+      const cleanStats = playerStats.map((stat) => ({
+        playerId: stat.playerId,
+        name: `${stat.firstName} ${stat.lastName}`,
+        position: stat.positionCode,
+        team: {
+          name: stat.team?.name || '',
+          shortName: stat.team?.short_name || '',
+        },
+        gamesPlayed: stat.gamesPlayed,
+        goals: stat.goals,
+        assists: stat.assists,
+        points: stat.points,
+        plusMinus: stat.plusMinus,
+        penaltyMinutes: stat.penaltyMinutes,
+        shots: stat.shots,
+        shootingPct: stat.shootingPct,
+        timeOnIcePerGame: stat.timeOnIcePerGame,
+        powerPlayGoals: stat.powerPlayGoals,
+        powerPlayPoints: stat.powerPlayPoints,
+        shorthandedGoals: stat.shorthandedGoals,
+        gameWinningGoals: stat.gameWinningGoals,
+      }))
+
+      return jsonResult({
+        year: targetYear,
+        sortBy: targetSortBy,
+        total: cleanStats.length,
+        players: cleanStats
+      }, false)
+    } catch (error) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Error fetching player stats: ${error instanceof Error ? error.message : 'Unknown error'}`
+        }],
+        isError: true
+      }
+    }
+  }
+})

--- a/server/mcp/tools/nhl-player-stats.ts
+++ b/server/mcp/tools/nhl-player-stats.ts
@@ -21,7 +21,8 @@ export default defineMcpTool({
 
     const targetYear = year ?? DEFAULT_YEAR
     const targetSortBy = sortBy ?? 'points'
-    const targetLimit = Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT)
+    const targetLimit =
+      limit == null ? DEFAULT_LIMIT : Math.max(1, Math.min(Math.trunc(limit), MAX_LIMIT))
 
     try {
       let playerStats

--- a/server/mcp/tools/nhl-standings.ts
+++ b/server/mcp/tools/nhl-standings.ts
@@ -9,12 +9,11 @@ export default defineMcpTool({
     year: z.number().describe('The year to fetch the standings for (e.g., 2023, 2024, 2026)')
   },
   handler: async ({ year }) => {
-    const { convex } = useRuntimeConfig()
-    const convexUrl = convex.url
+    const runtimeConfig = useRuntimeConfig()
+    const convexClient = new ConvexHttpClient(runtimeConfig.convex.url)
 
     try {
-      const convex = new ConvexHttpClient(convexUrl)
-      const result = await convex.query(api.standings.getStandingsWithTeams, { year })
+      const result = await convexClient.query(api.standings.getStandingsWithTeams, { year })
 
       // Transform to clean format without internal IDs and metadata
       const cleanStandings = result.map((item) => ({

--- a/server/mcp/tools/nhl-team-info.ts
+++ b/server/mcp/tools/nhl-team-info.ts
@@ -1,0 +1,102 @@
+import { z } from 'zod'
+import { ConvexHttpClient } from 'convex/browser'
+import { api } from '~/convex/_generated/api'
+import type { Id } from '~/convex/_generated/dataModel'
+
+const DEFAULT_YEAR = 2026
+
+export default defineMcpTool({
+  name: 'nhl-team-info',
+  description: 'Get detailed information about a specific NHL team including standings and all players',
+  inputSchema: {
+    team: z.string().describe('Team short name (e.g., "MTL", "TOR", "NYR")'),
+    year: z.number().optional().describe('The season year (e.g., 2024, 2025, 2026). Defaults to current season')
+  },
+  handler: async ({ team, year }) => {
+    const runtimeConfig = useRuntimeConfig()
+    const convexClient = new ConvexHttpClient(runtimeConfig.convex.url)
+
+    const targetYear = year ?? DEFAULT_YEAR
+
+    try {
+      const teamData = await convexClient.query(api.teams.getTeamByShortName, { shortName: team.toUpperCase() })
+
+      if (!teamData) {
+        return {
+          content: [{
+            type: 'text',
+            text: `Team "${team}" not found. Please use a valid team short name (e.g., "MTL", "TOR", "NYR")`
+          }],
+          isError: true
+        }
+      }
+
+      let division = null
+      if (teamData.division_id) {
+        const divisions = await convexClient.query(api.teams.getDivisions)
+        division = divisions.find((d: { _id: Id<'divisions'> }) => d._id === teamData.division_id)
+      }
+
+      const standings = await convexClient.query(api.standings.getStandingByTeamAndYear, {
+        teamId: teamData._id,
+        year: targetYear
+      })
+
+      const allPlayers = await convexClient.query(api.playerStats.getPlayerStatsWithTeamsByTeamSorted, {
+        year: targetYear,
+        teamId: teamData._id,
+        sortBy: 'points',
+        sortOrder: 'desc'
+      })
+
+      const cleanPlayers = allPlayers.map((stat) => ({
+        playerId: stat.playerId,
+        name: `${stat.firstName} ${stat.lastName}`,
+        position: stat.positionCode,
+        gamesPlayed: stat.gamesPlayed,
+        goals: stat.goals,
+        assists: stat.assists,
+        points: stat.points,
+        plusMinus: stat.plusMinus,
+      }))
+
+      const cleanStandings = standings ? {
+        year: standings.year,
+        gamesPlayed: standings.gp,
+        wins: standings.w,
+        losses: standings.l,
+        otLosses: standings.otl,
+        points: standings.pts,
+        goalFor: standings.gf,
+        goalAgainst: standings.ga,
+        goalDifferential: Number(standings.diff),
+        home: standings.home,
+        away: standings.away,
+        l10: standings.l10,
+        streak: standings.streak,
+      } : null
+
+      return jsonResult({
+        team: {
+          name: teamData.name,
+          city: teamData.city,
+          shortName: teamData.short_name,
+        },
+        division: division ? {
+          name: division.name,
+          conference: division.conference,
+        } : null,
+        standings: cleanStandings,
+        players: cleanPlayers
+      }, false)
+    } catch (error) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Error fetching team info for "${team}": ${error instanceof Error ? error.message : 'Unknown error'}`
+        }],
+        isError: true
+      }
+    }
+  }
+})

--- a/server/mcp/tools/nhl-teams-list.ts
+++ b/server/mcp/tools/nhl-teams-list.ts
@@ -34,6 +34,16 @@ export default defineMcpTool({
     division: z.string().optional().describe('Filter by division name (e.g., "Atlantic", "Metropolitan", "Central", "Pacific")')
   },
   handler: async ({ conference, division }) => {
+    if (conference && division) {
+      return {
+        content: [{
+          type: 'text',
+          text: 'Cannot specify both conference and division. Please provide only one filter.'
+        }],
+        isError: true
+      }
+    }
+
     const runtimeConfig = useRuntimeConfig()
     const convexClient = new ConvexHttpClient(runtimeConfig.convex.url)
 

--- a/server/mcp/tools/nhl-teams-list.ts
+++ b/server/mcp/tools/nhl-teams-list.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod'
+import { ConvexHttpClient } from 'convex/browser'
+import { api } from '~/convex/_generated/api'
+import type { Id } from '~/convex/_generated/dataModel'
+
+interface Team {
+  _id: Id<'teams'>
+  short_name: string
+  city: string
+  name: string
+  year: number
+  division_id?: Id<'divisions'>
+}
+
+interface Division {
+  _id: Id<'divisions'>
+  name: string
+  conference: string
+}
+
+interface CleanTeam {
+  name: string
+  city: string
+  shortName: string
+  division: string | null
+  conference: string | null
+}
+
+export default defineMcpTool({
+  name: 'nhl-teams-list',
+  description: 'Get list of all NHL teams with optional filtering by conference or division',
+  inputSchema: {
+    conference: z.enum(['EAST', 'WEST']).optional().describe('Filter by conference: EAST or WEST'),
+    division: z.string().optional().describe('Filter by division name (e.g., "Atlantic", "Metropolitan", "Central", "Pacific")')
+  },
+  handler: async ({ conference, division }) => {
+    const runtimeConfig = useRuntimeConfig()
+    const convexClient = new ConvexHttpClient(runtimeConfig.convex.url)
+
+    try {
+      let teams: Team[]
+
+      if (division) {
+        teams = await convexClient.query(api.teams.getTeamsByDivisionName, { division })
+      } else if (conference) {
+        teams = await convexClient.query(api.teams.getTeamsByConference, { conference })
+      } else {
+        teams = await convexClient.query(api.teams.getTeams)
+      }
+
+      const divisions = await convexClient.query(api.teams.getDivisions)
+      const divisionMap = new Map<string, Division>(divisions.map((d: Division) => [d._id.toString(), d]))
+
+      const cleanTeams: CleanTeam[] = teams.map((team: Team) => {
+        const div = team.division_id ? divisionMap.get(team.division_id.toString()) : undefined
+
+        return {
+          name: team.name,
+          city: team.city,
+          shortName: team.short_name,
+          division: div?.name || null,
+          conference: div?.conference || null,
+        }
+      })
+
+      const sortedTeams = cleanTeams.sort((a: CleanTeam, b: CleanTeam) => {
+        if (a.conference === b.conference) {
+          if (a.division === b.division) {
+            return a.name.localeCompare(b.name)
+          }
+          return (a.division || '').localeCompare(b.division || '')
+        }
+        return (a.conference || '').localeCompare(b.conference || '')
+      })
+
+      return jsonResult({
+        total: sortedTeams.length,
+        conference: conference || null,
+        division: division || null,
+        teams: sortedTeams
+      }, false)
+    } catch (error) {
+      return {
+        content: [{
+          type: 'text',
+          text: `Error fetching teams list: ${error instanceof Error ? error.message : 'Unknown error'}`
+        }],
+        isError: true
+      }
+    }
+  }
+})

--- a/tests/visual/mcp-server.spec.ts
+++ b/tests/visual/mcp-server.spec.ts
@@ -72,9 +72,19 @@ test.describe('MCP Server', () => {
     expect(result.result?.tools).toBeDefined()
     expect(result.result?.tools?.length).toBeGreaterThan(0)
 
-    // Check that nhl-standings tool exists
-    const standingsTool = result.result?.tools?.find((t) => t.name === 'nhl-standings')
-    expect(standingsTool).toBeDefined()
+    // Check that all expected tools exist
+    const tools = result.result?.tools ?? []
+    const toolNames = tools.map((t) => t.name)
+
+    expect(toolNames).toContain('nhl-standings')
+    expect(toolNames).toContain('nhl-player-stats')
+    expect(toolNames).toContain('nhl-team-info')
+    expect(toolNames).toContain('nhl-player-details')
+    expect(toolNames).toContain('nhl-player-search')
+    expect(toolNames).toContain('nhl-teams-list')
+
+    // Verify nhl-standings description
+    const standingsTool = tools.find((t) => t.name === 'nhl-standings')
     expect(standingsTool?.description?.toLowerCase()).toContain('standings')
   })
 
@@ -115,9 +125,16 @@ test.describe('MCP Server', () => {
     expect(result.result?.prompts).toBeDefined()
     expect(result.result?.prompts?.length).toBeGreaterThan(0)
 
-    // Check that get-standings prompt exists
-    const standingsPrompt = result.result?.prompts?.find((p) => p.name === 'get-standings')
-    expect(standingsPrompt).toBeDefined()
+    // Check that all expected prompts exist
+    const prompts = result.result?.prompts ?? []
+    const promptNames = prompts.map((p) => p.name)
+
+    expect(promptNames).toContain('get-standings')
+    expect(promptNames).toContain('get-player-stats')
+    expect(promptNames).toContain('get-team-info')
+    expect(promptNames).toContain('get-player-details')
+    expect(promptNames).toContain('get-teams-list')
+    expect(promptNames).toContain('search-players')
   })
 
   test('should provide server info on initialize', async ({ request }) => {
@@ -134,5 +151,231 @@ test.describe('MCP Server', () => {
     expect(result.result?.protocolVersion).toBeDefined()
     expect(result.result?.serverInfo).toBeDefined()
     expect(result.result?.serverInfo?.name).toBe('nhlstats')
+  })
+
+  test('should call nhl-player-stats tool successfully', async ({ request }) => {
+    const result = await mcpRequest(request, 'tools/call', {
+      name: 'nhl-player-stats',
+      arguments: { year: 2026, sortBy: 'points', limit: 10 }
+    })
+
+    expect(result.result).toBeDefined()
+    expect(result.result?.content).toBeDefined()
+    expect(result.result?.content?.length).toBeGreaterThan(0)
+
+    const textContent = result.result?.content?.find((c: McpContent) => c.type === 'text')
+    expect(textContent).toBeDefined()
+    expect(textContent?.text).toBeDefined()
+
+    // The result should be valid JSON
+    const data = JSON.parse(textContent!.text as string)
+    expect(data).toHaveProperty('year')
+    expect(data).toHaveProperty('sortBy')
+    expect(data).toHaveProperty('total')
+    expect(data).toHaveProperty('players')
+    expect(Array.isArray(data.players)).toBe(true)
+
+    // If players are returned, verify structure
+    if (data.players.length > 0) {
+      const firstPlayer = data.players[0]
+      expect(firstPlayer).toHaveProperty('playerId')
+      expect(firstPlayer).toHaveProperty('name')
+      expect(firstPlayer).toHaveProperty('position')
+      expect(firstPlayer).toHaveProperty('team')
+      expect(firstPlayer).toHaveProperty('points')
+      expect(firstPlayer).toHaveProperty('goals')
+      expect(firstPlayer).toHaveProperty('assists')
+    }
+  })
+
+  test('should call nhl-player-stats with team filter', async ({ request }) => {
+    const result = await mcpRequest(request, 'tools/call', {
+      name: 'nhl-player-stats',
+      arguments: { year: 2026, team: 'MTL', limit: 5 }
+    })
+
+    expect(result.result).toBeDefined()
+    expect(result.result?.content).toBeDefined()
+
+    const textContent = result.result?.content?.find((c: McpContent) => c.type === 'text')
+    expect(textContent).toBeDefined()
+
+    const data = JSON.parse(textContent!.text as string)
+    expect(data.players.length).toBeLessThanOrEqual(5)
+  })
+
+  test('should call nhl-team-info tool successfully', async ({ request }) => {
+    const result = await mcpRequest(request, 'tools/call', {
+      name: 'nhl-team-info',
+      arguments: { team: 'MTL', year: 2026 }
+    })
+
+    expect(result.result).toBeDefined()
+    expect(result.result?.content).toBeDefined()
+    expect(result.result?.content?.length).toBeGreaterThan(0)
+
+    const textContent = result.result?.content?.find((c: McpContent) => c.type === 'text')
+    expect(textContent).toBeDefined()
+    expect(textContent?.text).toBeDefined()
+
+    const data = JSON.parse(textContent!.text as string)
+    expect(data).toHaveProperty('team')
+    expect(data).toHaveProperty('division')
+    expect(data).toHaveProperty('standings')
+    expect(data).toHaveProperty('players')
+
+    expect(data.team).toHaveProperty('name')
+    expect(data.team).toHaveProperty('city')
+    expect(data.team).toHaveProperty('shortName')
+
+    expect(Array.isArray(data.players)).toBe(true)
+  })
+
+  test('should call nhl-team-info with invalid team', async ({ request }) => {
+    const result = await mcpRequest(request, 'tools/call', {
+      name: 'nhl-team-info',
+      arguments: { team: 'INVALID', year: 2026 }
+    })
+
+    expect(result.result).toBeDefined()
+    expect(result.result?.content).toBeDefined()
+
+    const textContent = result.result?.content?.find((c: McpContent) => c.type === 'text')
+    expect(textContent).toBeDefined()
+    expect(textContent?.text).toContain('not found')
+  })
+
+  test('should call nhl-player-details tool successfully', async ({ request }) => {
+    // Using Connor McDavid's player ID (8478402) as a known player
+    const result = await mcpRequest(request, 'tools/call', {
+      name: 'nhl-player-details',
+      arguments: { playerId: 8478402, year: 2026 }
+    })
+
+    expect(result.result).toBeDefined()
+    expect(result.result?.content).toBeDefined()
+
+    const textContent = result.result?.content?.find((c: McpContent) => c.type === 'text')
+    expect(textContent).toBeDefined()
+
+    // If player found, verify structure
+    const text = textContent?.text ?? ''
+    if (!text.includes('not found')) {
+      const data = JSON.parse(text)
+      expect(data).toHaveProperty('playerId')
+      expect(data).toHaveProperty('name')
+      expect(data).toHaveProperty('position')
+      expect(data).toHaveProperty('team')
+      expect(data).toHaveProperty('season')
+      expect(data).toHaveProperty('scoring')
+      expect(data).toHaveProperty('advanced')
+    }
+  })
+
+  test('should call nhl-teams-list tool successfully', async ({ request }) => {
+    const result = await mcpRequest(request, 'tools/call', {
+      name: 'nhl-teams-list',
+      arguments: {}
+    })
+
+    expect(result.result).toBeDefined()
+    expect(result.result?.content).toBeDefined()
+
+    const textContent = result.result?.content?.find((c: McpContent) => c.type === 'text')
+    expect(textContent).toBeDefined()
+
+    const data = JSON.parse(textContent!.text as string)
+    expect(data).toHaveProperty('total')
+    expect(data).toHaveProperty('teams')
+    expect(Array.isArray(data.teams)).toBe(true)
+    expect(data.teams.length).toBeGreaterThan(0)
+
+    const firstTeam = data.teams[0]
+    expect(firstTeam).toHaveProperty('name')
+    expect(firstTeam).toHaveProperty('city')
+    expect(firstTeam).toHaveProperty('shortName')
+  })
+
+  test('should call nhl-teams-list with conference filter', async ({ request }) => {
+    const result = await mcpRequest(request, 'tools/call', {
+      name: 'nhl-teams-list',
+      arguments: { conference: 'EAST' }
+    })
+
+    expect(result.result).toBeDefined()
+
+    const textContent = result.result?.content?.find((c: McpContent) => c.type === 'text')
+    expect(textContent).toBeDefined()
+
+    const data = JSON.parse(textContent!.text as string)
+    expect(data.conference).toBe('EAST')
+    expect(data.teams.length).toBeGreaterThan(0)
+
+    // All teams should be from Eastern Conference
+    for (const team of data.teams) {
+      expect(team.conference).toBe('EAST')
+    }
+  })
+
+  test('should call nhl-player-search tool successfully', async ({ request }) => {
+    const result = await mcpRequest(request, 'tools/call', {
+      name: 'nhl-player-search',
+      arguments: { query: 'Connor', limit: 10 }
+    })
+
+    expect(result.result).toBeDefined()
+    expect(result.result?.content).toBeDefined()
+
+    const textContent = result.result?.content?.find((c: McpContent) => c.type === 'text')
+    expect(textContent).toBeDefined()
+
+    const data = JSON.parse(textContent!.text as string)
+    expect(data).toHaveProperty('query')
+    expect(data).toHaveProperty('team')
+    expect(data).toHaveProperty('total')
+    expect(data).toHaveProperty('players')
+    expect(Array.isArray(data.players)).toBe(true)
+
+    // If players are returned, verify structure
+    if (data.players.length > 0) {
+      const firstPlayer = data.players[0]
+      expect(firstPlayer).toHaveProperty('playerId')
+      expect(firstPlayer).toHaveProperty('name')
+      expect(firstPlayer).toHaveProperty('position')
+      expect(firstPlayer).toHaveProperty('team')
+      expect(firstPlayer).toHaveProperty('goals')
+      expect(firstPlayer).toHaveProperty('assists')
+      expect(firstPlayer).toHaveProperty('points')
+    }
+  })
+
+  test('should call nhl-player-search with team filter', async ({ request }) => {
+    const result = await mcpRequest(request, 'tools/call', {
+      name: 'nhl-player-search',
+      arguments: { query: 'Connor', team: 'EDM', limit: 5 }
+    })
+
+    expect(result.result).toBeDefined()
+
+    const textContent = result.result?.content?.find((c: McpContent) => c.type === 'text')
+    expect(textContent).toBeDefined()
+
+    const data = JSON.parse(textContent!.text as string)
+    expect(data.query).toBe('Connor')
+    expect(data.team).toBe('EDM')
+  })
+
+  test('should call nhl-player-search with invalid team', async ({ request }) => {
+    const result = await mcpRequest(request, 'tools/call', {
+      name: 'nhl-player-search',
+      arguments: { query: 'Connor', team: 'INVALID' }
+    })
+
+    expect(result.result).toBeDefined()
+    expect(result.result?.content).toBeDefined()
+
+    const textContent = result.result?.content?.find((c: McpContent) => c.type === 'text')
+    expect(textContent).toBeDefined()
+    expect(textContent?.text).toContain('not found')
   })
 })


### PR DESCRIPTION
New Tools:
- nhl-player-stats: Get player statistics with team/sorting filters
- nhl-team-info: Get team details, standings, and all players
- nhl-player-details: Get detailed stats for a specific player by ID
- nhl-teams-list: List all teams with conference/division filtering
- nhl-player-search: Search players by name with optional team filter

closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiple NHL MCP tools and prompts: player stats (filter/sort/limit), player details, player search, team info, and teams list; new server queries for team and player lookups.
* **Documentation**
  * Updated tools list to "Available Tools" with descriptions, parameters, and example queries.
* **Tests**
  * Added visual/RPC tests covering all new tools and prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->